### PR TITLE
fix problem where atomicAdd of 0 for long long creates atom.or.b64 wh…

### DIFF
--- a/openmp/libomptarget/deviceRTLs/common/state-queue.h
+++ b/openmp/libomptarget/deviceRTLs/common/state-queue.h
@@ -37,7 +37,7 @@ private:
   INLINE static uint32_t ID(uint32_t ticket);
   INLINE bool IsServing(uint32_t slot, uint32_t id);
   INLINE void PushElement(uint32_t slot, ElementType *element);
-  INLINE ElementType *PopElement(uint32_t slot);
+  INLINE ElementType *PopElement(uint32_t slot, uint64_t * zero);
   INLINE void DoneServing(uint32_t slot, uint32_t id);
 
 public:


### PR DESCRIPTION

John, this is a bit of a hack but it gets my k4000 (sm_30) working.  The #if defined .. changes nothing for amdgcn and any cuda_arch >= 35.  This results in the generation of a ptx atom.or.b64.   With cuda_arch<35, the source indirectly adds a zero.  This avoids the generation of atom.or.b64 and the fail I was getting for sm_30 compiles.  We need this or something else that does not fail soon in amd-stg-openmp soon.  