### PR TITLE
sm_30 atomicAdd does not work for 64 bit adds.  So we just add the va…

### DIFF
--- a/openmp/libomptarget/deviceRTLs/common/target_atomic.h
+++ b/openmp/libomptarget/deviceRTLs/common/target_atomic.h
@@ -16,7 +16,14 @@
 #include "target_impl.h"
 
 template <typename T> INLINE T __kmpc_atomic_add(T *address, T val) {
+#if defined(__AMDGCN__) || ( defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 320 ) || !defined(__clang__)
   return atomicAdd(address, val);
+#else
+  //  Hack for k4000 without a working  64bit atomic add
+  uint newval = (uint) val;
+  uint* uintaddr = (uint *) address; // take little end for 32 bit atomic op
+  return (T) atomicAdd(uintaddr, newval);
+#endif
 }
 
 template <typename T> INLINE T __kmpc_atomic_inc(T *address, T val) {


### PR DESCRIPTION
This is another hack but better than the last.   Lets discuss. 