### PR TITLE
Slightly simplify diff against trunk

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -210,9 +210,13 @@ void CodeGenModule::createOpenMPRuntime() {
   switch (getTriple().getArch()) {
   case llvm::Triple::nvptx:
   case llvm::Triple::nvptx64:
-  case llvm::Triple::amdgcn:
     assert(getLangOpts().OpenMPIsDevice &&
            "OpenMP NVPTX is only prepared to deal with device code.");
+    OpenMPRuntime.reset(new CGOpenMPRuntimeNVPTX(*this));
+    break;
+  case llvm::Triple::amdgcn:
+    assert(getLangOpts().OpenMPIsDevice &&
+           "OpenMP AMDGCN is only prepared to deal with device code.");
     OpenMPRuntime.reset(new CGOpenMPRuntimeNVPTX(*this));
     break;
   default:
@@ -923,9 +927,7 @@ static bool shouldAssumeDSOLocal(const CodeGenModule &CGM,
 }
 
 void CodeGenModule::setDSOLocal(llvm::GlobalValue *GV) const {
-  bool assumelocal = shouldAssumeDSOLocal(*this, GV);
-  GV->setDSOLocal(assumelocal);
-  // GV->setDSOLocal(shouldAssumeDSOLocal(*this, GV));
+  GV->setDSOLocal(shouldAssumeDSOLocal(*this, GV));
 }
 
 void CodeGenModule::setDLLImportDLLExport(llvm::GlobalValue *GV,


### PR DESCRIPTION
I'm intending to write 'new CGOpenMPRuntimeAMDGCN' in place of 'new CGOpenMPRuntimeNVPTX' in the near future, and this patch will help me keep the diff against trunk clearer.