### PR TITLE
Initialize IsNew and Pointer_IsNew in target_data_begin

### DIFF
--- a/openmp/libomptarget/src/omptarget.cpp
+++ b/openmp/libomptarget/src/omptarget.cpp
@@ -247,7 +247,7 @@ int target_data_begin(DeviceTy &Device, int32_t arg_num, void **args_base,
 
     // Address of pointer on the host and device, respectively.
     void *Pointer_HstPtrBegin, *Pointer_TgtPtrBegin;
-    bool IsNew, Pointer_IsNew;
+    bool IsNew = false, Pointer_IsNew = false;
     bool IsHostPtr = false;
     bool IsImplicit = arg_types[i] & OMP_TGT_MAPTYPE_IMPLICIT;
     // Force the creation of a device side copy of the data when:


### PR DESCRIPTION
These two locals were uninitialized at delcaration, and then passed by
reference to Device.getOrAllocTgtPtr which in turn did not assign on all
paths within the fucntion.

This caused Nekbone to fail at runtime along
with its reduced test case map_zero_bug.

Needs to be upstreamed.