### PR TITLE
support for a hostrpc service to call a host function with a function…

### DIFF
--- a/openmp/libomptarget/deviceRTLs/hostcall/src/hostcall_service_id.h
+++ b/openmp/libomptarget/deviceRTLs/hostcall/src/hostcall_service_id.h
@@ -54,6 +54,7 @@ enum hostcall_service_id {
   HOSTCALL_SERVICE_MALLOC,
   HOSTCALL_SERVICE_FREE,
   HOSTCALL_SERVICE_DEMO,
+  HOSTCALL_SERVICE_FUNCTIONCALL,
 };
 typedef enum hostcall_service_id hostcall_service_id_t;
 

--- a/openmp/libomptarget/deviceRTLs/hostcall/src/hostcall_stubs.h
+++ b/openmp/libomptarget/deviceRTLs/hostcall/src/hostcall_stubs.h
@@ -12,6 +12,7 @@ EXTERN char *  printf_alloc(uint32_t bufsz);
 EXTERN int     printf_execute(char * bufptr, uint32_t bufsz);
 EXTERN uint32_t __strlen_max(char*instr, uint32_t maxstrlen);
 EXTERN int     vector_product_zeros(int N, int*A, int*B, int*C);
+EXTERN void    hostrpc_fptr0(void* fptr);
 
 typedef struct hostcall_result_s{
   uint64_t arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7;

--- a/openmp/libomptarget/deviceRTLs/hostcall/src/hostcall_stubs.hip
+++ b/openmp/libomptarget/deviceRTLs/hostcall/src/hostcall_stubs.hip
@@ -28,6 +28,13 @@ EXTERN char * printf_alloc(uint32_t bufsz) {
   return (char *) result.arg1;
 }
 
+EXTERN void hostrpc_fptr0(void* fptr) {
+  uint64_t arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7;
+  arg0 = (uint64_t) fptr;
+  hostcall_result_t result = hostcall_invoke(PACK_VERS(HOSTCALL_SERVICE_FUNCTIONCALL),
+    arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7);
+}
+
 EXTERN int printf_execute(char * print_buffer, uint32_t bufsz) { 
   uint64_t arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7;
   __builtin_amdgcn_wave_barrier();

--- a/openmp/libomptarget/plugins/hsa/impl/hostcall_handlers.c
+++ b/openmp/libomptarget/plugins/hsa/impl/hostcall_handlers.c
@@ -62,6 +62,11 @@ void handler_HOSTCALL_SERVICE_FREE(void *cbdata, uint32_t service, uint64_t *pay
     atmi_free(device_buffer);
 }
 
+void handler_HOSTCALL_SERVICE_FUNCTIONCALL(void *cbdata, uint32_t service, uint64_t *payload) {
+  void (*fptr)() = (void*) payload[0];
+  (*fptr)();
+}
+
 int vector_product_zeros(int N, int*A, int*B, int*C) {
     int zeros = 0;
     for (int i =0 ; i<N; i++) {
@@ -97,4 +102,5 @@ void hostcall_register_all_handlers(amd_hostcall_consumer_t * c, void * cbdata) 
     amd_hostcall_register_service(c,HOSTCALL_SERVICE_MALLOC, handler_HOSTCALL_SERVICE_MALLOC, cbdata);
     amd_hostcall_register_service(c,HOSTCALL_SERVICE_FREE, handler_HOSTCALL_SERVICE_FREE, cbdata);
     amd_hostcall_register_service(c,HOSTCALL_SERVICE_DEMO, handler_HOSTCALL_SERVICE_DEMO, cbdata);
+    amd_hostcall_register_service(c,HOSTCALL_SERVICE_FUNCTIONCALL, handler_HOSTCALL_SERVICE_FUNCTIONCALL, cbdata);
 }

--- a/openmp/libomptarget/plugins/hsa/impl/hostcall_service_id.h
+++ b/openmp/libomptarget/plugins/hsa/impl/hostcall_service_id.h
@@ -54,6 +54,7 @@ enum hostcall_service_id {
   HOSTCALL_SERVICE_MALLOC,
   HOSTCALL_SERVICE_FREE,
   HOSTCALL_SERVICE_DEMO,
+  HOSTCALL_SERVICE_FUNCTIONCALL,
 };
 typedef enum hostcall_service_id hostcall_service_id_t;
 

--- a/openmp/libomptarget/src/api.cpp
+++ b/openmp/libomptarget/src/api.cpp
@@ -20,6 +20,13 @@
 #include <cstring>
 #include <cstdlib>
 
+// This is the host fallback version of hostrpc_fptr0
+EXTERN void hostrpc_fptr0(void* fnptr) {
+  void (*fptr)() = (void (*)()) fnptr;
+  DP("host fallback for device function hostrpc_fptr0 fptr:%p\n",fptr);
+  (*fptr)();
+}
+
 EXTERN int omp_get_num_devices(void) {
   RTLsMtx->lock();
   size_t Devices_size = Devices.size();

--- a/openmp/libomptarget/src/exports
+++ b/openmp/libomptarget/src/exports
@@ -25,6 +25,7 @@ VERS1.0 {
     omp_target_memcpy_rect;
     omp_target_associate_ptr;
     omp_target_disassociate_ptr;
+    hostrpc_fptr0;
     __kmpc_push_target_tripcount;
   local:
     *;


### PR DESCRIPTION
… pointer with no arguments.  hostrpc_fptr0() .  The demo of this is in examples/openmp/host_function.