### PR TITLE
Allow any archive file to be part of device compilation. Fixes isse #89.

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7086,14 +7086,12 @@ static bool isArchiveOfBundlesFileName(StringRef FilePath) {
   if (!FileName.endswith(".a"))
     return false;
 
-  if (!FileName.startswith("lib"))
-    return false;
-
-  if (FileName.contains("amdgcn") && FileName.contains("gfx"))
-    return false;
-
-  if (FileName.contains("nvptx") && FileName.contains("sm_"))
-    return false;
+  if (FileName.startswith("lib")) {
+    if (FileName.contains("amdgcn") && FileName.contains("gfx"))
+      return false;
+    if (FileName.contains("nvptx") && FileName.contains("sm_"))
+      return false;
+  }
 
   return true;
 }


### PR DESCRIPTION
Archive files had to start with "lib" to be unbundled correctly. This patch removes this restriction.
