### PR TITLE
Provide an inline version of comgr

### DIFF
--- a/openmp/libomptarget/plugins/hsa/CMakeLists.txt
+++ b/openmp/libomptarget/plugins/hsa/CMakeLists.txt
@@ -76,6 +76,8 @@ include_directories(
 add_library(omptarget.rtl.hsa SHARED
       impl/atmi.cpp
       impl/atmi_interop_hsa.cpp
+      impl/comgr-metadata.cpp
+      impl/comgr.cpp
       impl/cputask.cpp
       impl/data.cpp
       impl/kernel.cpp
@@ -92,20 +94,38 @@ add_library(omptarget.rtl.hsa SHARED
       src/rtl.cpp 
       )
 
+# Macros
+target_compile_definitions(omptarget.rtl.hsa PUBLIC -DHSA_USE_EXTERNAL_COMGR=0)
+    
+# Parts of ATMI require rtti (e.g. cputask uses dynamic_cast)
+# and parts of comgr do not work with rtti
+# comgr also compiles with no-strict-aliasing
+set_source_files_properties(impl/comgr-metadata.cpp impl/comgr.cpp PROPERTIES COMPILE_FLAGS "-fno-rtti -fno-strict-aliasing")
+
 # Install plugin under the lib destination folder.
 # When we build for debug, OPENMP_LIBDIR_SUFFIX get set to -debug
 install(TARGETS omptarget.rtl.hsa LIBRARY DESTINATION "lib${OPENMP_LIBDIR_SUFFIX}")
 
 # We need the AOMP specific build of ATMI that has HSA_INTEROP turned on. 
-# Also, the AOMP specific build of ATMI has seperate release and debug builds. 
+# Also, the AOMP specific build of ATMI has seperate release and debug builds.
+
+
+# Statically link in the (many) LLVM libraries used by comgr
+llvm_map_components_to_libnames(LLVM_LIBS
+  ${LLVM_TARGETS_TO_BUILD})
+
 target_link_libraries(
   omptarget.rtl.hsa
-  -L${LLVM_LIBDIR}${OPENMP_LIBDIR_SUFFIX} -lamd_comgr -lpthread -ldl -Wl,-rpath,${LLVM_LIBDIR}${OPENMP_LIBDIR_SUFFIX}
+  PUBLIC
+  -L${LLVM_LIBDIR}${OPENMP_LIBDIR_SUFFIX} -lpthread -ldl -Wl,-rpath,${LLVM_LIBDIR}${OPENMP_LIBDIR_SUFFIX}
   -L${LIBOMPTARGET_DEP_LIBHSA_LIBRARIES_DIRS} -L${LIBOMPTARGET_DEP_LIBHSAKMT_LIBRARIES_DIRS} -lhsa-runtime64 -lhsakmt  -Wl,-rpath,${LIBOMPTARGET_DEP_LIBHSA_LIBRARIES_DIRS},-rpath,${LIBOMPTARGET_DEP_LIBHSAKMT_LIBRARIES_DIRS}
-  -L${LLVM_LIBDIR} -lLLVMAMDGPUDesc -lLLVMAMDGPUUtils -lLLVMMC -lLLVMCore -lLLVMSupport -Wl,-rpath,${LLVM_LIBDIR}
+  -Wl,-rpath,${LLVM_LIBDIR}
   -lelf
+  -ltinfo
   "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/../exports"
   "-Wl,-z,defs"
+  PRIVATE
+  ${LLVM_LIBS}
   )
 
 # Report to the parent scope that we are building a plugin for hsa

--- a/openmp/libomptarget/plugins/hsa/impl/comgr-metadata.cpp
+++ b/openmp/libomptarget/plugins/hsa/impl/comgr-metadata.cpp
@@ -1,0 +1,183 @@
+/*******************************************************************************
+ *
+ * University of Illinois/NCSA
+ * Open Source License
+ *
+ * Copyright (c) 2018 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * with the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ *     * Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimers.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimers in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *     * Neither the names of Advanced Micro Devices, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this Software without specific prior written permission.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH
+ * THE SOFTWARE.
+ *
+ ******************************************************************************/
+#if !HSA_USE_EXTERNAL_COMGR
+#include "comgr-metadata.h"
+
+#include "llvm/BinaryFormat/ELF.h"
+#include "llvm/BinaryFormat/MsgPackDocument.h"
+#include "llvm/Object/ELFObjectFile.h"
+#include "llvm/Support/MathExtras.h"
+#include "llvm/Support/MemoryBuffer.h"
+
+using namespace llvm;
+using namespace llvm::object;
+
+namespace COMGR {
+namespace metadata {
+
+template <typename ELFT> using Elf_Note = typename ELFT::Note;
+
+static Expected<std::unique_ptr<ELFObjectFileBase>>
+getELFObjectFileBase(DataObject *DataP) {
+  std::unique_ptr<MemoryBuffer> Buf =
+      MemoryBuffer::getMemBuffer(StringRef(DataP->Data, DataP->Size));
+
+  Expected<std::unique_ptr<ObjectFile>> ObjOrErr =
+      ObjectFile::createELFObjectFile(*Buf);
+
+  if (auto Err = ObjOrErr.takeError())
+    return std::move(Err);
+
+  return unique_dyn_cast<ELFObjectFileBase>(std::move(*ObjOrErr));
+}
+
+/// Process all notes in the given ELF object file, passing them each to @p
+/// ProcessNote.
+///
+/// @p ProcessNote should return @c true when the desired note is found, which
+/// signals to stop searching and return @c AMD_COMGR_STATUS_SUCCESS. It should
+/// return @c false otherwise to continue iteration.
+///
+/// @returns @c AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT If all notes are
+/// processed without @p ProcessNote returning @c true, otherwise
+/// AMD_COMGR_STATUS_SUCCESS.
+template <class ELFT, typename F>
+static amd_comgr_status_t processElfNotes(const ELFObjectFile<ELFT> *Obj,
+                                          F ProcessNote) {
+  const ELFFile<ELFT> *ELFFile = Obj->getELFFile();
+
+  bool Found = false;
+
+  auto ProgramHeadersOrError = ELFFile->program_headers();
+  if (errorToBool(ProgramHeadersOrError.takeError()))
+    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+
+  for (const auto &Phdr : *ProgramHeadersOrError) {
+    if (Phdr.p_type != ELF::PT_NOTE)
+      continue;
+    Error Err = Error::success();
+    for (const auto &Note : ELFFile->notes(Phdr, Err))
+      if (ProcessNote(Note)) {
+        Found = true;
+        break;
+      }
+    if (errorToBool(std::move(Err)))
+      return AMD_COMGR_STATUS_ERROR;
+    if (Found)
+      return AMD_COMGR_STATUS_SUCCESS;
+  }
+
+  auto SectionsOrError = ELFFile->sections();
+  if (errorToBool(SectionsOrError.takeError()))
+    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+
+  for (const auto &Shdr : *SectionsOrError) {
+    if (Shdr.sh_type != ELF::SHT_NOTE)
+      continue;
+    Error Err = Error::success();
+    for (const auto &Note : ELFFile->notes(Shdr, Err))
+      if (ProcessNote(Note)) {
+        Found = true;
+        break;
+      }
+    if (errorToBool(std::move(Err)))
+      return AMD_COMGR_STATUS_ERROR;
+    if (Found)
+      return AMD_COMGR_STATUS_SUCCESS;
+  }
+
+  return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+}
+
+// PAL currently produces MsgPack metadata in a note with this ID.
+// FIXME: Unify with HSA note types?
+#define PAL_METADATA_NOTE_TYPE 13
+
+template <class ELFT>
+static amd_comgr_status_t getElfMetadataRoot(const ELFObjectFile<ELFT> *Obj,
+                                             DataMeta *MetaP) {
+  amd_comgr_status_t NoteStatus = AMD_COMGR_STATUS_SUCCESS;
+  auto ProcessNote = [&](const Elf_Note<ELFT> &Note) {
+    auto DescString =
+        StringRef(reinterpret_cast<const char *>(Note.getDesc().data()),
+                  Note.getDesc().size());
+    if (Note.getName() == "AMD" &&
+        Note.getType() == ELF::NT_AMD_AMDGPU_HSA_METADATA) {
+      MetaP->MetaDoc->EmitIntegerBooleans = false;
+      MetaP->MetaDoc->RawDocument.clear();
+      if (!MetaP->MetaDoc->Document.fromYAML(DescString))
+        return false;
+      MetaP->DocNode = MetaP->MetaDoc->Document.getRoot();
+      return true;
+    } else if (((Note.getName() == "AMD" || Note.getName() == "AMDGPU") &&
+                Note.getType() == PAL_METADATA_NOTE_TYPE) ||
+               (Note.getName() == "AMDGPU" &&
+                Note.getType() == ELF::NT_AMDGPU_METADATA)) {
+      MetaP->MetaDoc->EmitIntegerBooleans = true;
+      MetaP->MetaDoc->RawDocument = std::string(DescString);
+      if (!MetaP->MetaDoc->Document.readFromBlob(MetaP->MetaDoc->RawDocument,
+                                                 false))
+        return false;
+      MetaP->DocNode = MetaP->MetaDoc->Document.getRoot();
+      return true;
+    }
+    return false;
+  };
+  if (auto ElfStatus = processElfNotes(Obj, ProcessNote))
+    return ElfStatus;
+  if (NoteStatus)
+    return NoteStatus;
+  return AMD_COMGR_STATUS_SUCCESS;
+}
+
+amd_comgr_status_t getMetadataRoot(DataObject *DataP, DataMeta *MetaP) {
+  auto ObjOrErr = getELFObjectFileBase(DataP);
+  if (errorToBool(ObjOrErr.takeError()))
+    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+  auto Obj = ObjOrErr->get();
+
+  if (auto ELF32LE = dyn_cast<ELF32LEObjectFile>(Obj))
+    return getElfMetadataRoot(ELF32LE, MetaP);
+  if (auto ELF64LE = dyn_cast<ELF64LEObjectFile>(Obj))
+    return getElfMetadataRoot(ELF64LE, MetaP);
+  if (auto ELF32BE = dyn_cast<ELF32BEObjectFile>(Obj))
+    return getElfMetadataRoot(ELF32BE, MetaP);
+  auto ELF64BE = dyn_cast<ELF64BEObjectFile>(Obj);
+  return getElfMetadataRoot(ELF64BE, MetaP);
+}
+
+} // namespace metadata
+} // namespace COMGR
+#endif // !HSA_USE_EXTERNAL_COMGR

--- a/openmp/libomptarget/plugins/hsa/impl/comgr-metadata.h
+++ b/openmp/libomptarget/plugins/hsa/impl/comgr-metadata.h
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ *
+ * University of Illinois/NCSA
+ * Open Source License
+ *
+ * Copyright (c) 2018 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * with the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ *     * Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimers.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimers in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *     * Neither the names of Advanced Micro Devices, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this Software without specific prior written permission.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH
+ * THE SOFTWARE.
+ *
+ ******************************************************************************/
+
+#ifndef COMGR_METADATA_H
+#define COMGR_METADATA_H
+#if !HSA_USE_EXTERNAL_COMGR
+
+#include "comgr.h"
+
+namespace COMGR {
+namespace metadata {
+
+amd_comgr_status_t getMetadataRoot(DataObject *DataP, DataMeta *MetaP);
+
+} // namespace metadata
+} // namespace COMGR
+
+#endif // !HSA_USE_EXTERNAL_COMGR
+#endif

--- a/openmp/libomptarget/plugins/hsa/impl/comgr.cpp
+++ b/openmp/libomptarget/plugins/hsa/impl/comgr.cpp
@@ -1,0 +1,454 @@
+/*******************************************************************************
+ *
+ * University of Illinois/NCSA
+ * Open Source License
+ *
+ * Copyright (c) 2018 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * with the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ *     * Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimers.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimers in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *     * Neither the names of Advanced Micro Devices, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this Software without specific prior written permission.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH
+ * THE SOFTWARE.
+ *
+ ******************************************************************************/
+#if !HSA_USE_EXTERNAL_COMGR
+#include "comgr.h"
+#include "comgr-metadata.h"
+#include <string>
+
+using namespace llvm;
+using namespace COMGR;
+
+bool COMGR::isDataKindValid(amd_comgr_data_kind_t DataKind) {
+  return DataKind > AMD_COMGR_DATA_KIND_UNDEF &&
+         DataKind <= AMD_COMGR_DATA_KIND_LAST;
+}
+
+amd_comgr_status_t COMGR::setCStr(char *&Dest, StringRef Src, size_t *Size) {
+  free(Dest);
+  Dest = reinterpret_cast<char *>(malloc(Src.size() + 1));
+  if (!Dest)
+    return AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES;
+  memcpy(Dest, Src.data(), Src.size());
+  Dest[Src.size()] = '\0';
+  if (Size)
+    *Size = Src.size();
+  return AMD_COMGR_STATUS_SUCCESS;
+}
+
+
+
+DataObject::DataObject(amd_comgr_data_kind_t DataKind)
+    : DataKind(DataKind), Data(nullptr), Name(nullptr), Size(0), RefCount(1)
+ {}
+
+DataObject::~DataObject() {
+  DataKind = AMD_COMGR_DATA_KIND_UNDEF;
+  free(Data);
+  free(Name);
+  Size = 0;
+
+}
+
+DataObject *DataObject::allocate(amd_comgr_data_kind_t DataKind) {
+  return new (std::nothrow) DataObject(DataKind);
+}
+
+void DataObject::release() {
+  if (--RefCount == 0)
+    delete this;
+}
+
+amd_comgr_status_t DataObject::setName(llvm::StringRef Name) {
+  return setCStr(this->Name, Name);
+}
+
+amd_comgr_status_t DataObject::setData(llvm::StringRef Data) {
+  return setCStr(this->Data, Data, &Size);
+}
+
+
+amd_comgr_metadata_kind_t DataMeta::getMetadataKind() {
+  if (DocNode.isScalar())
+    return AMD_COMGR_METADATA_KIND_STRING;
+  else if (DocNode.isArray())
+    return AMD_COMGR_METADATA_KIND_LIST;
+  else if (DocNode.isMap())
+    return AMD_COMGR_METADATA_KIND_MAP;
+  else
+    // treat as NULL
+    return AMD_COMGR_METADATA_KIND_NULL;
+}
+
+std::string DataMeta::convertDocNodeToString(msgpack::DocNode DocNode) {
+  assert(DocNode.isScalar() && "cannot convert non-scalar DocNode to string");
+  if (MetaDoc->EmitIntegerBooleans &&
+      DocNode.getKind() == msgpack::Type::Boolean)
+    return DocNode.getBool() ? "1" : "0";
+  return DocNode.toString();
+}
+
+amd_comgr_status_t AMD_API
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    amd_comgr_status_string
+    //
+    (amd_comgr_status_t Status, const char **StatusString) {
+  if (!StatusString || Status < AMD_COMGR_STATUS_SUCCESS ||
+      Status > AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES)
+    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+
+  switch (Status) {
+  case AMD_COMGR_STATUS_SUCCESS:
+    *StatusString = "SUCCESS";
+    break;
+  case AMD_COMGR_STATUS_ERROR:
+    *StatusString = "ERROR";
+    break;
+  case AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT:
+    *StatusString = "INVALID_ARGUMENT";
+    break;
+  case AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES:
+    *StatusString = "OUT_OF_RESOURCES";
+    break;
+  }
+
+  return AMD_COMGR_STATUS_SUCCESS;
+}
+
+// API functions on Data Object
+
+amd_comgr_status_t AMD_API
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    amd_comgr_create_data
+    //
+    (amd_comgr_data_kind_t DataKind, amd_comgr_data_t *Data) {
+  if (!Data || DataKind <= AMD_COMGR_DATA_KIND_UNDEF ||
+      DataKind > AMD_COMGR_DATA_KIND_LAST)
+    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+
+  DataObject *DataP = DataObject::allocate(DataKind);
+  if (!DataP)
+    return AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES;
+
+  *Data = DataObject::convert(DataP);
+
+  return AMD_COMGR_STATUS_SUCCESS;
+}
+
+amd_comgr_status_t AMD_API
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    amd_comgr_release_data
+    //
+    (amd_comgr_data_t Data) {
+  DataObject *DataP = DataObject::convert(Data);
+
+  if (!DataP || !DataP->hasValidDataKind())
+    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+
+  DataP->release();
+
+  return AMD_COMGR_STATUS_SUCCESS;
+}
+
+amd_comgr_status_t AMD_API
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    amd_comgr_get_data_kind
+    //
+    (amd_comgr_data_t Data, amd_comgr_data_kind_t *DataKind) {
+  DataObject *DataP = DataObject::convert(Data);
+
+  if (!DataP || !DataP->hasValidDataKind() || !DataKind) {
+    *DataKind = AMD_COMGR_DATA_KIND_UNDEF;
+    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+  }
+
+  *DataKind = DataP->DataKind;
+
+  return AMD_COMGR_STATUS_SUCCESS;
+}
+
+amd_comgr_status_t AMD_API
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    amd_comgr_set_data
+    //
+    (amd_comgr_data_t Data, size_t Size, const char *Bytes) {
+  DataObject *DataP = DataObject::convert(Data);
+
+  if (!DataP || !DataP->hasValidDataKind() || !Size || !Bytes)
+    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+
+  return DataP->setData(StringRef(Bytes, Size));
+}
+
+amd_comgr_status_t AMD_API
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    amd_comgr_get_data
+    //
+    (amd_comgr_data_t Data, size_t *Size, char *Bytes) {
+  DataObject *DataP = DataObject::convert(Data);
+
+  if (!DataP || !DataP->Data || !DataP->hasValidDataKind() || !Size)
+    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+
+  if (Bytes)
+    memcpy(Bytes, DataP->Data, *Size);
+  else
+    *Size = DataP->Size;
+
+  return AMD_COMGR_STATUS_SUCCESS;
+}
+
+amd_comgr_status_t AMD_API
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    amd_comgr_set_data_name
+    //
+    (amd_comgr_data_t Data, const char *Name) {
+  DataObject *DataP = DataObject::convert(Data);
+
+  if (!DataP || !DataP->hasValidDataKind())
+    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+
+  return DataP->setName(Name);
+}
+
+amd_comgr_status_t AMD_API
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    amd_comgr_get_data_name
+    //
+    (amd_comgr_data_t Data, size_t *Size, char *Name) {
+  DataObject *DataP = DataObject::convert(Data);
+
+  if (!DataP || !DataP->hasValidDataKind() || !Size)
+    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+
+  if (Name)
+    memcpy(Name, DataP->Name, *Size);
+  else
+    *Size = strlen(DataP->Name) + 1; // include terminating null
+
+  return AMD_COMGR_STATUS_SUCCESS;
+}
+
+
+
+amd_comgr_status_t AMD_API
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    amd_comgr_get_data_metadata
+    //
+    (amd_comgr_data_t Data, amd_comgr_metadata_node_t *MetadataNode) {
+  DataObject *DataP = DataObject::convert(Data);
+
+  if (!DataP || !DataP->hasValidDataKind() ||
+      DataP->DataKind == AMD_COMGR_DATA_KIND_UNDEF || !MetadataNode)
+    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+
+  std::unique_ptr<DataMeta> MetaP(new (std::nothrow) DataMeta());
+  if (!MetaP)
+    return AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES;
+
+  MetaDocument *MetaDoc = new (std::nothrow) MetaDocument();
+  if (!MetaDoc)
+    return AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES;
+
+  MetaP->MetaDoc.reset(MetaDoc);
+  MetaP->DocNode = MetaP->MetaDoc->Document.getRoot();
+
+  if (auto Status = metadata::getMetadataRoot(DataP, MetaP.get()))
+    return Status;
+
+  // if no metadata found in this data object, still return SUCCESS but
+  // with default NULL kind
+
+  *MetadataNode = DataMeta::convert(MetaP.release());
+
+  return AMD_COMGR_STATUS_SUCCESS;
+}
+
+amd_comgr_status_t AMD_API
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    amd_comgr_destroy_metadata
+    //
+    (amd_comgr_metadata_node_t MetadataNode) {
+  DataMeta *MetaP = DataMeta::convert(MetadataNode);
+  delete MetaP;
+  return AMD_COMGR_STATUS_SUCCESS;
+}
+
+amd_comgr_status_t AMD_API
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    amd_comgr_get_metadata_kind
+    //
+    (amd_comgr_metadata_node_t MetadataNode,
+     amd_comgr_metadata_kind_t *MetadataKind) {
+  DataMeta *MetaP = DataMeta::convert(MetadataNode);
+
+  if (!MetadataKind)
+    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+
+  *MetadataKind = MetaP->getMetadataKind();
+
+  return AMD_COMGR_STATUS_SUCCESS;
+}
+
+amd_comgr_status_t AMD_API
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    amd_comgr_get_metadata_string
+    //
+    (amd_comgr_metadata_node_t MetadataNode, size_t *Size, char *String) {
+  DataMeta *MetaP = DataMeta::convert(MetadataNode);
+
+  if (MetaP->getMetadataKind() != AMD_COMGR_METADATA_KIND_STRING || !Size)
+    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+
+  std::string Str = MetaP->convertDocNodeToString(MetaP->DocNode);
+
+  if (String)
+    memcpy(String, Str.c_str(), *Size);
+  else
+    *Size = Str.size() + 1;
+
+  return AMD_COMGR_STATUS_SUCCESS;
+}
+
+amd_comgr_status_t AMD_API
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    amd_comgr_get_metadata_map_size
+    //
+    (amd_comgr_metadata_node_t MetadataNode, size_t *Size) {
+  DataMeta *MetaP = DataMeta::convert(MetadataNode);
+
+  if (MetaP->getMetadataKind() != AMD_COMGR_METADATA_KIND_MAP || !Size)
+    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+
+  *Size = MetaP->DocNode.getMap().size();
+
+  return AMD_COMGR_STATUS_SUCCESS;
+}
+
+amd_comgr_status_t AMD_API
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    amd_comgr_iterate_map_metadata
+    //
+    (amd_comgr_metadata_node_t MetadataNode,
+     amd_comgr_status_t (*Callback)(amd_comgr_metadata_node_t,
+                                    amd_comgr_metadata_node_t, void *),
+     void *UserData) {
+  DataMeta *MetaP = DataMeta::convert(MetadataNode);
+
+  if (MetaP->getMetadataKind() != AMD_COMGR_METADATA_KIND_MAP || !Callback)
+    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+
+  auto Map = MetaP->DocNode.getMap();
+
+  for (auto &KV : Map) {
+    if (KV.first.isEmpty() || KV.second.isEmpty())
+      return AMD_COMGR_STATUS_ERROR;
+    std::unique_ptr<DataMeta> KeyP(new (std::nothrow) DataMeta());
+    std::unique_ptr<DataMeta> ValueP(new (std::nothrow) DataMeta());
+    if (!KeyP || !ValueP)
+      return AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES;
+    KeyP->MetaDoc = MetaP->MetaDoc;
+    KeyP->DocNode = KV.first;
+    ValueP->MetaDoc = MetaP->MetaDoc;
+    ValueP->DocNode = KV.second;
+    (*Callback)(DataMeta::convert(KeyP.get()), DataMeta::convert(ValueP.get()),
+                UserData);
+  }
+
+  return AMD_COMGR_STATUS_SUCCESS;
+}
+
+amd_comgr_status_t AMD_API
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    amd_comgr_metadata_lookup
+    //
+    (amd_comgr_metadata_node_t MetadataNode, const char *Key,
+     amd_comgr_metadata_node_t *Value) {
+  DataMeta *MetaP = DataMeta::convert(MetadataNode);
+
+  if (MetaP->getMetadataKind() != AMD_COMGR_METADATA_KIND_MAP || !Key || !Value)
+    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+
+  for (auto Iter : MetaP->DocNode.getMap()) {
+    if (!Iter.first.isScalar() ||
+        StringRef(Key) != MetaP->convertDocNodeToString(Iter.first))
+      continue;
+
+    DataMeta *NewMetaP = new (std::nothrow) DataMeta();
+    if (!NewMetaP)
+      return AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES;
+
+    NewMetaP->MetaDoc = MetaP->MetaDoc;
+    NewMetaP->DocNode = Iter.second;
+    *Value = DataMeta::convert(NewMetaP);
+
+    return AMD_COMGR_STATUS_SUCCESS;
+  }
+
+  return AMD_COMGR_STATUS_ERROR;
+}
+
+amd_comgr_status_t AMD_API
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    amd_comgr_get_metadata_list_size
+    //
+    (amd_comgr_metadata_node_t MetadataNode, size_t *Size) {
+  DataMeta *MetaP = DataMeta::convert(MetadataNode);
+
+  if (MetaP->getMetadataKind() != AMD_COMGR_METADATA_KIND_LIST || !Size)
+    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+
+  *Size = MetaP->DocNode.getArray().size();
+
+  return AMD_COMGR_STATUS_SUCCESS;
+}
+
+amd_comgr_status_t AMD_API
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    amd_comgr_index_list_metadata
+    //
+    (amd_comgr_metadata_node_t MetadataNode, size_t Index,
+     amd_comgr_metadata_node_t *Value) {
+  DataMeta *MetaP = DataMeta::convert(MetadataNode);
+
+  if (MetaP->getMetadataKind() != AMD_COMGR_METADATA_KIND_LIST || !Value)
+    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+
+  auto List = MetaP->DocNode.getArray();
+
+  if (Index >= List.size())
+    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+
+  DataMeta *NewMetaP = new (std::nothrow) DataMeta();
+  if (!NewMetaP)
+    return AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES;
+
+  NewMetaP->MetaDoc = MetaP->MetaDoc;
+  NewMetaP->DocNode = List[Index];
+  *Value = DataMeta::convert(NewMetaP);
+
+  return AMD_COMGR_STATUS_SUCCESS;
+}
+
+#endif // !HSA_USE_EXTERNAL_COMGR

--- a/openmp/libomptarget/plugins/hsa/impl/comgr.h
+++ b/openmp/libomptarget/plugins/hsa/impl/comgr.h
@@ -1,0 +1,157 @@
+/*******************************************************************************
+ *
+ * University of Illinois/NCSA
+ * Open Source License
+ *
+ * Copyright (c) 2018 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * with the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ *     * Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimers.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimers in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *     * Neither the names of Advanced Micro Devices, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this Software without specific prior written permission.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH
+ * THE SOFTWARE.
+ *
+ ******************************************************************************/
+
+#ifndef COMGR_DATA_H_
+#define COMGR_DATA_H_
+#if !HSA_USE_EXTERNAL_COMGR
+
+#include "openmp_amd_comgr.h"
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/BinaryFormat/MsgPackDocument.h"
+
+
+namespace COMGR {
+struct DataMeta;
+
+/// Update @p Dest to point to a newly allocated C-style (null terminated)
+/// string with the contents of @p Src, optionally updating @p Size with the
+/// length of the string (not including the null terminator).
+///
+/// If @p Dest is non-null, it will first be freed.
+///
+/// @p Src may contain null bytes.
+amd_comgr_status_t setCStr(char *&Dest, llvm::StringRef Src,
+                           size_t *Size = nullptr);
+
+/// Return `true` if the kind is valid, or false otherwise.
+bool isDataKindValid(amd_comgr_data_kind_t DataKind);
+
+struct DataObject {
+
+  // Allocate a new DataObject and return a pointer to it.
+  static DataObject *allocate(amd_comgr_data_kind_t DataKind);
+
+  // Decrement the refcount of this DataObject, and free it when it reaches 0.
+  void release();
+
+  static amd_comgr_data_t convert(DataObject *Data) {
+    amd_comgr_data_t Handle = {
+        static_cast<uint64_t>(reinterpret_cast<uintptr_t>(Data))};
+    return Handle;
+  }
+
+  static const amd_comgr_data_t convert(const DataObject *Data) {
+    const amd_comgr_data_t Handle = {
+        static_cast<uint64_t>(reinterpret_cast<uintptr_t>(Data))};
+    return Handle;
+  }
+
+  static DataObject *convert(amd_comgr_data_t Data) {
+    return reinterpret_cast<DataObject *>(Data.handle);
+  }
+
+  bool hasValidDataKind() { return isDataKindValid(DataKind); }
+
+  amd_comgr_status_t setName(llvm::StringRef Name);
+  amd_comgr_status_t setData(llvm::StringRef Data);
+  void setMetadata(DataMeta *Metadata);
+
+  amd_comgr_data_kind_t DataKind;
+  char *Data;
+  char *Name;
+  size_t Size;
+  int RefCount;
+
+private:
+  // We require this type be allocated via new, specifically through calling
+  // allocate, because we want to be able to `delete this` in release. To make
+  // sure the type is not constructed without new, or destructed without
+  // checking the reference count, we mark the constructor and destructor
+  // private.
+  DataObject(amd_comgr_data_kind_t Kind);
+  ~DataObject();
+};
+
+
+
+// Elements common to all DataMeta which refer to the same "document".
+struct MetaDocument {
+  // The MsgPack document, which owns all memory allocated during parsing.
+  llvm::msgpack::Document Document;
+  // The MsgPack parser is zero-copy, so we retain a copy of the input buffer.
+  std::string RawDocument;
+  // The old YAML parser would produce the strings "true" and "false" for
+  // booleans, whereas the old MsgPack parser produced "0" and "1". The new
+  // universal parser produces "true" and "false", but we need to remain
+  // backwards compatible, so we set a flag when parsing MsgPack.
+  bool EmitIntegerBooleans = false;
+};
+
+struct DataMeta {
+  static amd_comgr_metadata_node_t convert(DataMeta *Meta) {
+    amd_comgr_metadata_node_t Handle = {
+        static_cast<uint64_t>(reinterpret_cast<uintptr_t>(Meta))};
+    return Handle;
+  }
+
+  static const amd_comgr_metadata_node_t convert(const DataMeta *Meta) {
+    const amd_comgr_metadata_node_t Handle = {
+        static_cast<uint64_t>(reinterpret_cast<uintptr_t>(Meta))};
+    return Handle;
+  }
+
+  static DataMeta *convert(amd_comgr_metadata_node_t Meta) {
+    return reinterpret_cast<DataMeta *>(Meta.handle);
+  }
+
+  amd_comgr_metadata_kind_t getMetadataKind();
+  // Get the canonical string representation of @p DocNode, assuming
+  // it is a scalar node.
+  std::string convertDocNodeToString(llvm::msgpack::DocNode DocNode);
+
+  // This DataMeta's "meta document", shared by all instances derived from the
+  // same metadata.
+  std::shared_ptr<MetaDocument> MetaDoc;
+  // This DataMeta's "view" into the shared llvm::msgpack::Document.
+  llvm::msgpack::DocNode DocNode;
+};
+
+
+} // namespace COMGR
+
+#endif // !HSA_USE_EXTERNAL_COMGR
+#endif // header guard

--- a/openmp/libomptarget/plugins/hsa/impl/openmp_amd_comgr.h
+++ b/openmp/libomptarget/plugins/hsa/impl/openmp_amd_comgr.h
@@ -1,0 +1,721 @@
+/*******************************************************************************
+*
+* University of Illinois/NCSA
+* Open Source License
+*
+* Copyright (c) 2018 Advanced Micro Devices, Inc. All Rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* with the Software without restriction, including without limitation the
+* rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+* sell copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+*     * Redistributions of source code must retain the above copyright notice,
+*       this list of conditions and the following disclaimers.
+*
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimers in the
+*       documentation and/or other materials provided with the distribution.
+*
+*     * Neither the names of Advanced Micro Devices, Inc. nor the names of its
+*       contributors may be used to endorse or promote products derived from
+*       this Software without specific prior written permission.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH
+* THE SOFTWARE.
+*
+*******************************************************************************/
+
+#ifndef OPENMP_AMD_COMGR_H_
+#define OPENMP_AMD_COMGR_H_
+
+/*******************************************************************************
+ *
+ * This runtime library works by parsing information from device images.
+ * The implementation of this parsing varies with different distributions of the
+ * toolchain. This file helps abstract the differences.
+ *
+ * ROCm:
+ *  The ROCm toolchain uses a library named ROCm-CompilerSupport, which exports
+ *  a header amd_comgr, to implement image parsing and various other tasks. This
+ *  is the primary use case for setting HSA_USE_EXTERNAL_COMGR
+ *
+ * LLVM trunk:
+ *   The llvm toolchain prefers to keep the openmp host runtime standalone. When
+ *   compiling this library with trunk, the subset of amd_comgr.h is available
+ *   in this header file, with a corresponding implementation in the library
+ *
+ * AOMP:
+ *   The AOMP library follows LLVM trunk as above
+ *
+ * Other:
+ *   Other toolchains may prefer to use ROCm-CompilerSupport, this local
+ *   implementation or do something entirely different
+ *
+ ********************************************************************************/
+
+#if HSA_USE_EXTERNAL_COMGR
+
+#include "amd_comgr.h"
+
+#else
+
+// This is a the subset of amd_comgr.h used by this library
+// It is a direct copy & paste so that diff can be used to inspect whether the
+// version in ROCm-CompilerSupport has diverged, and so that the comments are
+// available to users of this local implementation.
+
+#include <stddef.h> /* size_t */
+#include <stdint.h>
+
+#ifndef __cplusplus
+#include <stdbool.h>  /* bool */
+#endif /* __cplusplus */
+
+/* Placeholder for calling convention and import/export macros */
+#ifndef AMD_CALL
+#define AMD_CALL
+#endif
+
+#ifndef AMD_EXPORT_DECORATOR
+#ifdef __GNUC__
+#define AMD_EXPORT_DECORATOR __attribute__ ((visibility ("default")))
+#else
+#define AMD_EXPORT_DECORATOR __declspec(dllexport)
+#endif
+#endif
+
+#ifndef AMD_IMPORT_DECORATOR
+#ifdef __GNUC__
+#define AMD_IMPORT_DECORATOR
+#else
+#define AMD_IMPORT_DECORATOR __declspec(dllimport)
+#endif
+#endif
+
+#define AMD_API_EXPORT AMD_EXPORT_DECORATOR AMD_CALL
+#define AMD_API_IMPORT AMD_IMPORT_DECORATOR AMD_CALL
+
+#ifndef AMD_API
+#ifdef AMD_EXPORT
+#define AMD_API AMD_API_EXPORT
+#else
+#define AMD_API AMD_API_IMPORT
+#endif
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif  /* __cplusplus */
+
+/** \defgroup codeobjectmanager Code Object Manager
+ *  @{
+ *
+ * @brief The code object manager is a callable library that provides
+ * operations for creating and inspecting code objects.
+ *
+ * The library provides handles to various objects. Concurrent execution of
+ * operations is supported provided all objects accessed by each concurrent
+ * operation are disjoint. For example, the @p amd_comgr_data_set_t handles
+ * passed to operations must be disjoint, together with all the @p
+ * amd_comgr_data_t handles that have been added to it. The exception is that
+ * the default device library data object handles can be non-disjoint as they
+ * are imutable.
+ *
+ * The library supports generating and inspecting code objects that
+ * contain machine code for a certain set of instruction set
+ * arhitectures (isa). The set of isa supported and information about
+ * the properties of the isa can be queried.
+ *
+ * The library supports performing an action that can take data
+ * objects of one kind, and generate new data objects of another kind.
+ *
+ * Data objects are referenced using handles using @p
+ * amd_comgr_data_t. The kinds of data objects are given
+ * by @p amd_comgr_data_kind_t.
+ *
+ * To perform an action, two @p amd_comgr_data_set_t
+ * objects are created. One is used to hold all the data objects
+ * needed by an action, and other is updated by the action with all
+ * the result data objects. In addition, an @p
+ * amd_comgr_action_info_t is created to hold
+ * information that controls the action. These are then passed to @p
+ * amd_comgr_do_action to perform an action specified by
+ * @p amd_comgr_action_kind_t.
+ *
+ * Some data objects can have associated metadata. There are
+ * operations for querying this metadata.
+ *
+ * The default device library that satisfies the requirements of the
+ * compiler action can be obtained.
+ *
+ * The library inspects some environment variables to aid in debugging. These
+ * include:
+ * - @p AMD_COMGR_SAVE_TEMPS: If this is set, and is not "0", the library does
+ *   not delete temporary files generated while executing compilation actions.
+ *   These files do not appear in the current working directory, but are
+ *   instead left in a platform-specific temporary directory (/tmp on Linux and
+ *   C:\Temp or the path found in the TEMP environment variable on Windows).
+ * - @p AMD_COMGR_REDIRECT_LOGS: If this is not set, or is set to "0", logs are
+ *   returned to the caller as normal. If this is set to "stdout"/"-" or
+ *   "stderr", logs are instead redirected to the standard output or error
+ *   stream, respectively. If this is set to any other value, it is interpreted
+ *   as a filename which logs should be appended to. Logs may be redirected
+ *   irrespective of whether logging is enabled.
+ * - @p AMD_COMGR_EMIT_VERBOSE_LOGS: If this is set, and is not "0", logs will
+ *   include additional Comgr-specific informational messages.
+ */
+
+/**
+ * @brief Status codes.
+ */
+typedef enum amd_comgr_status_s {
+  /**
+   * The function has been executed successfully.
+   */
+  AMD_COMGR_STATUS_SUCCESS = 0x0,
+  /**
+   * A generic error has occurred.
+   */
+  AMD_COMGR_STATUS_ERROR = 0x1,
+  /**
+   * One of the actual arguments does not meet a precondition stated
+   * in the documentation of the corresponding formal argument.
+   */
+  AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT = 0x2,
+  /**
+   * Failed to allocate the necessary resources.
+   */
+  AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES = 0x3,
+} amd_comgr_status_t;
+
+
+/**
+ * @brief The kinds of data supported.
+ */
+typedef enum amd_comgr_data_kind_s {
+  /**
+   * No data is available.
+   */
+  AMD_COMGR_DATA_KIND_UNDEF = 0x0,
+  /**
+   * The data is a textual main source.
+   */
+  AMD_COMGR_DATA_KIND_SOURCE = 0x1,
+  /**
+   * The data is a textual source that is included in the main source
+   * or other include source.
+   */
+  AMD_COMGR_DATA_KIND_INCLUDE = 0x2,
+  /**
+   * The data is a precompiled-header source that is included in the main
+   * source or other include source.
+   */
+  AMD_COMGR_DATA_KIND_PRECOMPILED_HEADER = 0x3,
+  /**
+   * The data is a diagnostic output.
+   */
+  AMD_COMGR_DATA_KIND_DIAGNOSTIC = 0x4,
+  /**
+   * The data is a textual log output.
+   */
+  AMD_COMGR_DATA_KIND_LOG = 0x5,
+  /**
+   * The data is compiler LLVM IR bit code for a specific isa.
+   */
+  AMD_COMGR_DATA_KIND_BC = 0x6,
+  /**
+   * The data is a relocatable machine code object for a specific isa.
+   */
+  AMD_COMGR_DATA_KIND_RELOCATABLE = 0x7,
+  /**
+   * The data is an executable machine code object for a specific
+   * isa. An executable is the kind of code object that can be loaded
+   * and executed.
+   */
+  AMD_COMGR_DATA_KIND_EXECUTABLE = 0x8,
+  /**
+   * The data is a block of bytes.
+   */
+  AMD_COMGR_DATA_KIND_BYTES = 0x9,
+  /**
+   * The data is a fat binary (clang-offload-bundler output).
+   */
+  AMD_COMGR_DATA_KIND_FATBIN = 0x10,
+  /**
+   * Marker for last valid data kind.
+   */
+  AMD_COMGR_DATA_KIND_LAST = AMD_COMGR_DATA_KIND_FATBIN
+} amd_comgr_data_kind_t;
+
+/**
+ * @brief A handle to a data object.
+ *
+ * Data objects are used to hold the data which is either an input or
+ * output of a code object manager action.
+ */
+typedef struct amd_comgr_data_s {
+  uint64_t handle;
+} amd_comgr_data_t;
+
+/**
+ * @brief A handle to a metadata node.
+ *
+ * A metadata node handle is used to traverse the metadata associated
+ * with a data node.
+ */
+typedef struct amd_comgr_metadata_node_s {
+  uint64_t handle;
+} amd_comgr_metadata_node_t;
+
+/**
+ * @brief Create a data object that can hold data of a specified kind.
+ *
+ * Data objects are reference counted and are destroyed when the
+ * reference count reaches 0. When a data object is created its
+ * reference count is 1, it has 0 bytes of data, it has an empty name,
+ * and it has no metadata.
+ *
+ * @param[in] kind The kind of data the object is intended to hold.
+ *
+ * @param[out] data A handle to the data object created. Its reference
+ * count is set to 1.
+ *
+ * @retval ::AMD_COMGR_STATUS_SUCCESS The function has
+ * been executed successfully.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT @p
+ * kind is an invalid data kind, or @p
+ * AMD_COMGR_DATA_KIND_UNDEF. @p data is NULL.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES
+ * Unable to create the data object as out of resources.
+ */
+amd_comgr_status_t AMD_API
+amd_comgr_create_data(
+  amd_comgr_data_kind_t kind,
+  amd_comgr_data_t *data);
+
+ /**
+ * @brief Indicate that no longer using a data object handle.
+ *
+ * The reference count of the associated data object is
+ * decremented. If it reaches 0 it is destroyed.
+ *
+ * @param[in] data The data object to release.
+ *
+ * @retval ::AMD_COMGR_STATUS_SUCCESS The function has
+ * been executed successfully.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT @p
+ * data is an invalid data object, or has kind @p
+ * AMD_COMGR_DATA_KIND_UNDEF.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES
+ * Unable to update the data object as out of resources.
+ */
+amd_comgr_status_t AMD_API
+amd_comgr_release_data(
+  amd_comgr_data_t data);
+
+
+/**
+ * @brief Set the data content of a data object to the specified
+ * bytes.
+ *
+ * Any previous value of the data object is overwritten. Any metadata
+ * associated with the data object is also replaced which invalidates
+ * all metadata handles to the old metadata.
+ *
+ * @param[in] data The data object to update.
+ *
+ * @param[in] size The number of bytes in the data specified by @p bytes.
+ *
+ * @param[in] bytes The bytes to set the data object to. The bytes are
+ * copied into the data object and can be freed after the call.
+ *
+ * @retval ::AMD_COMGR_STATUS_SUCCESS The function has
+ * been executed successfully.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT @p
+ * data is an invalid data object, or has kind @p
+ * AMD_COMGR_DATA_KIND_UNDEF.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES
+ * Unable to update the data object as out of resources.
+ */
+amd_comgr_status_t AMD_API
+amd_comgr_set_data(
+  amd_comgr_data_t data,
+  size_t size,
+  const char* bytes);
+
+/**
+ * @brief Set the name associated with a data object.
+ *
+ * When compiling, the fle name of an include directive is used to
+ * reference the contents of the include data object with the same
+ * name. The name may also be used for other data objects in log and
+ * diagnostic output.
+ *
+ * @param[in] data The data object to update.
+ *
+ * @param[in] name A null terminated string that specifies the name to
+ * use for the data object. If NULL then the name is set to the empty
+ * string.
+ *
+ * @retval ::AMD_COMGR_STATUS_SUCCESS The function has
+ * been executed successfully.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT @p
+ * data is an invalid data object, or has kind @p
+ * AMD_COMGR_DATA_KIND_UNDEF.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES
+ * Unable to update the data object as out of resources.
+ */
+amd_comgr_status_t AMD_API
+amd_comgr_set_data_name(
+  amd_comgr_data_t data,
+  const char* name);
+
+/**
+ * @brief Get the data contents, and/or the size of the data
+ * associated with a data object.
+ *
+ * @param[in] data The data object to query.
+ *
+ * @param[in, out] size On entry, the size of @p bytes. On return, if @p bytes
+ * is NULL, set to the size of the data object contents.
+ *
+ * @param[out] bytes If not NULL, then the first @p size bytes of the
+ * data object contents is copied. If NULL, no data is copied, and
+ * only @p size is updated (useful in order to find the size of buffer
+ * required to copy the data).
+ *
+ * @retval ::AMD_COMGR_STATUS_SUCCESS The function has
+ * been executed successfully.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT @p
+ * data is an invalid data object, or has kind @p
+ * AMD_COMGR_DATA_KIND_UNDEF. @p size is NULL.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES
+ * Unable to update the data object as out of resources.
+ */
+amd_comgr_status_t AMD_API
+amd_comgr_get_data(
+  amd_comgr_data_t data,
+  size_t *size,
+  char *bytes);
+
+/**
+ * @brief Get the data object name and/or name length.
+ *
+ * @param[in] data The data object to query.
+ *
+ * @param[in, out] size On entry, the size of @p name. On return, if @p name is
+ * NULL, set to the size of the data object name including the terminating null
+ * character.
+ *
+ * @param[out] name If not NULL, then the first @p size characters of the
+ * data object name are copied. If NULL, no name is copied, and
+ * only @p size is updated (useful in order to find the size of buffer
+ * required to copy the name).
+ *
+ * @retval ::AMD_COMGR_STATUS_SUCCESS The function has
+ * been executed successfully.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT @p
+ * data is an invalid data object, or has kind @p
+ * AMD_COMGR_DATA_KIND_UNDEF. @p size is NULL.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES
+ * Unable to update the data object as out of resources.
+ */
+amd_comgr_status_t AMD_API
+amd_comgr_get_data_name(
+  amd_comgr_data_t data,
+  size_t *size,
+  char *name);
+
+ /**
+ * @brief Get a handle to the metadata of a data object.
+ *
+ * @param[in] data The data object to query.
+ *
+ * @param[out] metadata A handle to the metadata of the data
+ * object. If the data object has no metadata then the returned handle
+ * has a kind of @p AMD_COMGR_METADATA_KIND_NULL. The
+ * handle must be destroyed using @c amd_comgr_destroy_metadata.
+ *
+ * @retval ::AMD_COMGR_STATUS_SUCCESS The function has
+ * been executed successfully.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT @p
+ * data is an invalid data object, or has kind @p
+ * AMD_COMGR_DATA_KIND_UNDEF. @p metadata is NULL.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES
+ * Unable to update the data object as out of resources.
+ */
+amd_comgr_status_t AMD_API
+amd_comgr_get_data_metadata(
+  amd_comgr_data_t data,
+  amd_comgr_metadata_node_t *metadata);
+
+/**
+ * @brief Destroy a metadata handle.
+ *
+ * @param[in] metadata A metadata handle to destroy.
+ *
+ * @retval ::AMD_COMGR_STATUS_SUCCESS The function has been executed
+ * successfully.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT @p metadata is an invalid
+ * metadata handle.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES Unable to update metadata
+ * handle as out of resources.
+ */
+amd_comgr_status_t AMD_API
+amd_comgr_destroy_metadata(amd_comgr_metadata_node_t metadata);
+
+
+/**
+ * @brief The kinds of metadata nodes.
+ */
+typedef enum amd_comgr_metadata_kind_s {
+  /**
+   * The NULL metadata handle.
+   */
+  AMD_COMGR_METADATA_KIND_NULL = 0x0,
+  /**
+   * A sting value.
+   */
+  AMD_COMGR_METADATA_KIND_STRING = 0x1,
+  /**
+   * A map that consists of a set of key and value pairs.
+   */
+  AMD_COMGR_METADATA_KIND_MAP = 0x2,
+  /**
+   * A list that consists of a sequence of values.
+   */
+  AMD_COMGR_METADATA_KIND_LIST = 0x3,
+  /**
+   * Marker for last valid metadata kind.
+   */
+  AMD_COMGR_METADATA_KIND_LAST = AMD_COMGR_METADATA_KIND_LIST
+} amd_comgr_metadata_kind_t;
+
+/**
+ * @brief Get the kind of the metadata node.
+ *
+ * @param[in] metadata The metadata node to query.
+ *
+ * @param[out] kind The kind of the metadata node.
+ *
+ * @retval ::AMD_COMGR_STATUS_SUCCESS The function has
+ * been executed successfully.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT @p
+ * metadata is an invalid metadata node. @p kind is NULL.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES
+ * Unable to create the data object as out of resources.
+ */
+amd_comgr_status_t AMD_API
+amd_comgr_get_metadata_kind(
+  amd_comgr_metadata_node_t metadata,
+  amd_comgr_metadata_kind_t *kind);
+
+/**
+ * @brief Get the string and/or string length from a metadata string
+ * node.
+ *
+ * @param[in] metadata The metadata node to query.
+ *
+ * @param[in, out] size On entry, the size of @p string. On return, if @p
+ * string is NULL, set to the size of the string including the terminating null
+ * character.
+ *
+ * @param[out] string If not NULL, then the first @p size characters
+ * of the string are copied. If NULL, no string is copied, and only @p
+ * size is updated (useful in order to find the size of buffer required
+ * to copy the string).
+ *
+ * @retval ::AMD_COMGR_STATUS_SUCCESS The function has
+ * been executed successfully.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT @p
+ * metadata is an invalid metadata node, or does not have kind @p
+ * AMD_COMGR_METADATA_KIND_STRING. @p size is NULL.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES
+ * Unable to update the data object as out of resources.
+ */
+amd_comgr_status_t AMD_API
+amd_comgr_get_metadata_string(
+  amd_comgr_metadata_node_t metadata,
+  size_t *size,
+  char *string);
+
+/**
+ * @brief Get the map size from a metadata map node.
+ *
+ * @param[in] metadata The metadata node to query.
+ *
+ * @param[out] size The number of entries in the map.
+ *
+ * @retval ::AMD_COMGR_STATUS_SUCCESS The function has
+ * been executed successfully.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT @p
+ * metadata is an invalid metadata node, or not of kind @p
+ * AMD_COMGR_METADATA_KIND_MAP. @p size is NULL.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES
+ * Unable to update the data object as out of resources.
+ */
+amd_comgr_status_t AMD_API
+amd_comgr_get_metadata_map_size(
+  amd_comgr_metadata_node_t metadata,
+  size_t *size);
+
+/**
+ * @brief Iterate over the elements a metadata map node.
+ *
+ * @warning The metadata nodes which are passed to the callback are not owned
+ * by the callback, and are freed just after the callback returns. The callback
+ * must not save any references to its parameters between iterations.
+ *
+ * @param[in] metadata The metadata node to query.
+ *
+ * @param[in] callback The function to call for each entry in the map. The
+ * entry's key is passed in @p key, the entry's value is passed in @p value, and
+ * @p user_data is passed as @p user_data. If the function returns with a status
+ * other than @p AMD_COMGR_STATUS_SUCCESS then iteration is stopped.
+ *
+ * @param[in] user_data The value to pass to each invocation of @p
+ * callback. Allows context to be passed into the call back function.
+ *
+ * @retval ::AMD_COMGR_STATUS_SUCCESS The function has
+ * been executed successfully.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR An error was
+ * reported by @p callback.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT @p
+ * metadata is an invalid metadata node, or not of kind @p
+ * AMD_COMGR_METADATA_KIND_MAP. @p callback is NULL.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES
+ * Unable to iterate the metadata as out of resources.
+ */
+amd_comgr_status_t AMD_API
+amd_comgr_iterate_map_metadata(
+  amd_comgr_metadata_node_t metadata,
+  amd_comgr_status_t (*callback)(
+    amd_comgr_metadata_node_t key,
+    amd_comgr_metadata_node_t value,
+    void *user_data),
+  void *user_data);
+
+/**
+ * @brief Use a string key to lookup an element of a metadata map
+ * node and return the entry value.
+ *
+ * @param[in] metadata The metadata node to query.
+ *
+ * @param[in] key A null terminated string that is the key to lookup.
+ *
+ * @param[out] value The metadata node of the @p key element of the
+ * @p metadata map metadata node. The handle must be destroyed
+ * using @c amd_comgr_destroy_metadata.
+ *
+ * @retval ::AMD_COMGR_STATUS_SUCCESS The function has
+ * been executed successfully.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR The map has no entry
+ * with a string key with the value @p key.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT @p
+ * metadata is an invalid metadata node, or not of kind @p
+ * AMD_COMGR_METADATA_KIND_MAP. @p key or @p value is
+ * NULL.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES
+ * Unable to lookup metadata as out of resources.
+ */
+amd_comgr_status_t AMD_API
+amd_comgr_metadata_lookup(
+  amd_comgr_metadata_node_t metadata,
+  const char *key,
+  amd_comgr_metadata_node_t *value);
+
+/**
+ * @brief Get the list size from a metadata list node.
+ *
+ * @param[in] metadata The metadata node to query.
+ *
+ * @param[out] size The number of entries in the list.
+ *
+ * @retval ::AMD_COMGR_STATUS_SUCCESS The function has
+ * been executed successfully.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT @p
+ * metadata is an invalid metadata node, or does nopt have kind @p
+ * AMD_COMGR_METADATA_KIND_LIST. @p size is NULL.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES
+ * Unable to update the data object as out of resources.
+ */
+amd_comgr_status_t AMD_API
+amd_comgr_get_metadata_list_size(
+  amd_comgr_metadata_node_t metadata,
+  size_t *size);
+
+/**
+ * @brief Return the Nth metadata node of a list metadata node.
+ *
+ * @param[in] metadata The metadata node to query.
+ *
+ * @param[in] index The index being requested. The first list element
+ * is index 0.
+ *
+ * @param[out] value The metadata node of the @p index element of the
+ * @p metadata list metadata node. The handle must be destroyed
+ * using @c amd_comgr_destroy_metadata.
+ *
+ * @retval ::AMD_COMGR_STATUS_SUCCESS The function has
+ * been executed successfully.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT @p
+ * metadata is an invalid metadata node or not of kind @p
+ * AMD_COMGR_METADATA_INFO_LIST. @p index is greater
+ * than the number of list elements. @p value is NULL.
+ *
+ * @retval ::AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES
+ * Unable to update action data object as out of resources.
+ */
+amd_comgr_status_t AMD_API
+amd_comgr_index_list_metadata(
+  amd_comgr_metadata_node_t metadata,
+  size_t index,
+  amd_comgr_metadata_node_t *value);
+
+/** @} */
+
+#ifdef __cplusplus
+}  /* end extern "C" block */
+#endif
+
+#endif  /* HSA_USE_EXTERNAL_COMGR */
+#endif  /* header guard */

--- a/openmp/libomptarget/plugins/hsa/impl/system.cpp
+++ b/openmp/libomptarget/plugins/hsa/impl/system.cpp
@@ -14,7 +14,7 @@
 #include <set>
 #include <string>
 
-#include "amd_comgr.h"
+#include "openmp_amd_comgr.h"
 #include "internal.h"
 #include "machine.h"
 #include "realtimer.h"


### PR DESCRIPTION
This is a proposed solution to ROCm wanting to use comgr everywhere while trunk wants a minimal, self contained plugin. It assumes AOMP also wants the minimal, self contained plugin. The same code could be used by ATMI.

The code is presently derived from comgr, aggressively cut down to the symbols used by the ATMI implementation that is currently used by the plugin. It uses exactly the same interface, so that compiling with a macro set will use amd_comgr.h instead. If this direction is acceptable, we can then replace llvm's elf library with libelf, binary support with a cut down metadata reader etc.

Putting the patch up now to check that this direction is considered reasonable. This makes comgr optional, but doesn't yet make the llvm libraries optional.