### PR TITLE
use the clang generated symbol for each kernel ending in _kern_desc t…

### DIFF
--- a/clang/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -4361,13 +4361,15 @@ void CGOpenMPRuntime::emitKmpRoutineEntryT(QualType KmpInt32Ty) {
 void CGOpenMPRuntime::emitStructureKernelDesc(CodeGenModule &CGM,
                                               StringRef Name, int16_t WG_Size,
                                               int8_t Mode, int8_t HostServices,
-                                              int8_t MaxParallelLevel) {
+                                              int8_t MaxParallelLevel,
+                                              int16_t num_args) {
 
   // Create all device images
   llvm::Constant *AttrData[] = {
-      llvm::ConstantInt::get(CGM.Int16Ty, 2), // Version
-      llvm::ConstantInt::get(CGM.Int16Ty, 9), // Size in bytes
+      llvm::ConstantInt::get(CGM.Int16Ty, 3),  // Version
+      llvm::ConstantInt::get(CGM.Int16Ty, 12), // Size in bytes
       llvm::ConstantInt::get(CGM.Int16Ty, WG_Size),
+      llvm::ConstantInt::get(CGM.Int16Ty, num_args),
       llvm::ConstantInt::get(CGM.Int8Ty, Mode), // 0 => SPMD, 1 => GENERIC
       llvm::ConstantInt::get(CGM.Int8Ty, HostServices), // 1 => use HostServices
       llvm::ConstantInt::get(CGM.Int8Ty, MaxParallelLevel)}; // number of nests
@@ -4389,6 +4391,7 @@ QualType CGOpenMPRuntime::getTgtAttributeStructQTy() {
     addFieldToRecordDecl(C, RD, KmpInt16Ty); // Version
     addFieldToRecordDecl(C, RD, KmpInt16Ty); // Struct Size in bytes.
     addFieldToRecordDecl(C, RD, KmpInt16Ty); // WG_size
+    addFieldToRecordDecl(C, RD, KmpInt16Ty); // num_args
     addFieldToRecordDecl(C, RD, KmpInt8Ty);  // Mode
     addFieldToRecordDecl(C, RD, KmpInt8Ty);  // HostServices
     addFieldToRecordDecl(C, RD, KmpInt8Ty);  // MaxParallelLevel

--- a/clang/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -4360,19 +4360,22 @@ void CGOpenMPRuntime::emitKmpRoutineEntryT(QualType KmpInt32Ty) {
 /// Emit structure descriptor for a kernel
 void CGOpenMPRuntime::emitStructureKernelDesc(CodeGenModule &CGM,
                                               StringRef Name, int16_t WG_Size,
-                                              int8_t Mode, int8_t HostServices,
-                                              int8_t MaxParallelLevel,
-                                              int16_t num_args) {
+                                              int16_t NumArgs, int8_t Mode,
+                                              int8_t HostServices,
+                                              int8_t MaxParallelLevel) {
 
   // Create all device images
+  int8_t byte_reserve = 0;
   llvm::Constant *AttrData[] = {
       llvm::ConstantInt::get(CGM.Int16Ty, 3),  // Version
       llvm::ConstantInt::get(CGM.Int16Ty, 12), // Size in bytes
       llvm::ConstantInt::get(CGM.Int16Ty, WG_Size),
-      llvm::ConstantInt::get(CGM.Int16Ty, num_args),
+      llvm::ConstantInt::get(CGM.Int16Ty, NumArgs),
       llvm::ConstantInt::get(CGM.Int8Ty, Mode), // 0 => SPMD, 1 => GENERIC
       llvm::ConstantInt::get(CGM.Int8Ty, HostServices), // 1 => use HostServices
-      llvm::ConstantInt::get(CGM.Int8Ty, MaxParallelLevel)}; // number of nests
+      llvm::ConstantInt::get(CGM.Int8Ty, MaxParallelLevel), // number of nests
+      llvm::ConstantInt::get(CGM.Int8Ty,
+                             byte_reserve)}; // reserved for fuuture use
 
   llvm::GlobalVariable *AttrImages = createGlobalStruct(
       CGM, getTgtAttributeStructQTy(), isDefaultLocationConstant(), AttrData,
@@ -4391,10 +4394,11 @@ QualType CGOpenMPRuntime::getTgtAttributeStructQTy() {
     addFieldToRecordDecl(C, RD, KmpInt16Ty); // Version
     addFieldToRecordDecl(C, RD, KmpInt16Ty); // Struct Size in bytes.
     addFieldToRecordDecl(C, RD, KmpInt16Ty); // WG_size
-    addFieldToRecordDecl(C, RD, KmpInt16Ty); // num_args
+    addFieldToRecordDecl(C, RD, KmpInt16Ty); // NumArgs
     addFieldToRecordDecl(C, RD, KmpInt8Ty);  // Mode
     addFieldToRecordDecl(C, RD, KmpInt8Ty);  // HostServices
     addFieldToRecordDecl(C, RD, KmpInt8Ty);  // MaxParallelLevel
+    addFieldToRecordDecl(C, RD, KmpInt8Ty);  // reserved
     RD->completeDefinition();
     TgtAttributeStructQTy = C.getRecordType(RD);
   }

--- a/clang/lib/CodeGen/CGOpenMPRuntime.h
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.h
@@ -1695,9 +1695,8 @@ public:
 
   /// Emit structure descriptor for a kernel
   void emitStructureKernelDesc(CodeGenModule &CGM, StringRef Name,
-                               int16_t WG_Size, int8_t Mode,
-                               int8_t HostServices, int8_t MaxParallelLevel,
-                               int16_t num_args);
+                               int16_t WG_Size, int16_t NumArgs, int8_t Mode,
+                               int8_t HostServices, int8_t MaxParallelLevel);
 
   /// Emits OpenMP-specific function prolog.
   /// Required for device constructs.

--- a/clang/lib/CodeGen/CGOpenMPRuntime.h
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.h
@@ -1696,7 +1696,8 @@ public:
   /// Emit structure descriptor for a kernel
   void emitStructureKernelDesc(CodeGenModule &CGM, StringRef Name,
                                int16_t WG_Size, int8_t Mode,
-                               int8_t HostServices, int8_t MaxParallelLevel);
+                               int8_t HostServices, int8_t MaxParallelLevel,
+                               int16_t num_args);
 
   /// Emits OpenMP-specific function prolog.
   /// Required for device constructs.

--- a/clang/lib/CodeGen/CGOpenMPRuntimeNVPTX.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntimeNVPTX.cpp
@@ -1330,9 +1330,9 @@ void CGOpenMPRuntimeNVPTX::GenerateMetaData(CodeGenModule &CGM,
   // Emit a kernel descriptor for runtime.
   StringRef KernDescName = OutlinedFn->getName();
   CGOpenMPRuntime::emitStructureKernelDesc(
-      CGM, KernDescName, FlatAttr, IsGeneric,
+      CGM, KernDescName, FlatAttr, (int16_t)OutlinedFn->arg_size(), IsGeneric,
       1, // Uses HostServices
-      MaxParallelLevel, (int16_t)OutlinedFn->arg_size());
+      MaxParallelLevel);
   // Reset it to zero for any subsequent kernel
   MaxParallelLevel = 0;
 }

--- a/clang/lib/CodeGen/CGOpenMPRuntimeNVPTX.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntimeNVPTX.cpp
@@ -1329,10 +1329,10 @@ void CGOpenMPRuntimeNVPTX::GenerateMetaData(CodeGenModule &CGM,
   }
   // Emit a kernel descriptor for runtime.
   StringRef KernDescName = OutlinedFn->getName();
-  CGOpenMPRuntime::emitStructureKernelDesc(CGM, KernDescName, FlatAttr,
-                                           IsGeneric,
-                                           1, // Uses HostServices
-                                           MaxParallelLevel);
+  CGOpenMPRuntime::emitStructureKernelDesc(
+      CGM, KernDescName, FlatAttr, IsGeneric,
+      1, // Uses HostServices
+      MaxParallelLevel, (int16_t)OutlinedFn->arg_size());
   // Reset it to zero for any subsequent kernel
   MaxParallelLevel = 0;
 }

--- a/openmp/libomptarget/plugins/hsa/impl/atmi.cpp
+++ b/openmp/libomptarget/plugins/hsa/impl/atmi.cpp
@@ -3,15 +3,18 @@
  *
  * This file is distributed under the MIT License. See LICENSE.txt for details.
  *===------------------------------------------------------------------------*/
+#include "amd_hostcall.h"
 #include "rt.h"
 /*
  * Initialize/Finalize
  */
 atmi_status_t atmi_init(atmi_devtype_t devtype) {
+  atmi_hostcall_init();
   return core::Runtime::getInstance().Initialize(devtype);
 }
 
 atmi_status_t atmi_finalize() {
+  atmi_hostcall_terminate();
   return core::Runtime::getInstance().Finalize();
 }
 

--- a/openmp/libomptarget/plugins/hsa/impl/atmi_runtime.h
+++ b/openmp/libomptarget/plugins/hsa/impl/atmi_runtime.h
@@ -244,6 +244,22 @@ typedef struct atmi_kernel_s {
 } atmi_kernel_t;
 
 /**
+ * @brief Kernel Descriptor Structure
+ *
+ * @detail Keep this struct in sync wih getTgtAttributeStructQTy in
+ *         CGOpenMPRuntime.cpp.
+ * */
+typedef struct atmi_kern_desc_s {
+  uint16_t Version;
+  uint16_t TSize;
+  uint16_t WG_Size;
+  uint16_t num_args;
+  uint8_t Mode;
+  uint8_t HostServices;
+  uint8_t MaxParallelLevel;
+} atmi_kern_desc_t;
+
+/**
  * @brief Create an kernel opaque structure with all its architecture
  * specific implementations.
  *

--- a/openmp/libomptarget/plugins/hsa/impl/system.cpp
+++ b/openmp/libomptarget/plugins/hsa/impl/system.cpp
@@ -1533,7 +1533,7 @@ hsa_status_t populate_InfoTables(hsa_executable_t executable,
       atmi_status_t err = atmi_memcpy(&kdv, (void *)info.addr, sizeof(kdv));
       if (err != ATMI_STATUS_SUCCESS) {
         DEBUG_PRINT("Copying device to host. hostptr:%p device:%p size:%u\n",
-                    (void *)&kdv, info.addr, KernDescSize);
+                    (void *)&kdv, info.addr, sizeof(kdv));
         ErrorCheck(Copying data for kernel descriptor symbol,
                  HSA_STATUS_ERROR_INVALID_CODE_OBJECT);
       }

--- a/openmp/libomptarget/plugins/hsa/src/rtl.cpp
+++ b/openmp/libomptarget/plugins/hsa/src/rtl.cpp
@@ -28,9 +28,6 @@
 // Header from ATMI interface
 #include "atmi_interop_hsa.h"
 #include "atmi_runtime.h"
-// Header from hostcall
-#include "amd_hostcall.h"
-
 #include "omptargetplugin.h"
 
 // Get static gpu grid values from clang target-specific constants managed
@@ -291,8 +288,6 @@ public:
       DP("Error when initializing HSA-ATMI\n");
       return;
     }
-    // Init hostcall soon after initializing ATMI
-    atmi_hostcall_init();
 
     HSAAgents = find_gpu_agents();
     NumberOfDevices = (int)HSAAgents.size();   
@@ -353,8 +348,6 @@ public:
 
   ~RTLDeviceInfoTy() {
     DP("Finalizing the HSA-ATMI DeviceInfo.\n");
-    // Terminate hostcall before finalizing ATMI
-    atmi_hostcall_terminate();
     atmi_finalize();
   }
 };

--- a/openmp/libomptarget/plugins/hsa/src/rtl.cpp
+++ b/openmp/libomptarget/plugins/hsa/src/rtl.cpp
@@ -751,16 +751,7 @@ __tgt_target_table *__tgt_rtl_load_binary(int32_t device_id,
     int16_t MaxParLevVal = 0;
 
     // get Kernel Descriptor if present.
-    // Keep struct in sync wih getTgtAttributeStructQTy in CGOpenMPRuntime.cpp
-    struct KernDescValType {
-      uint16_t Version;
-      uint16_t TSize;
-      uint16_t WG_Size;
-      uint8_t Mode;
-      uint8_t HostServices;
-      uint8_t MaxParallelLevel;
-    };
-    struct KernDescValType KernDescVal;
+    atmi_kern_desc_t KernDescVal;
     std::string KernDescNameStr(e->name);
     KernDescNameStr += "_kern_desc";
     const char *KernDescName = KernDescNameStr.c_str();
@@ -792,6 +783,7 @@ __tgt_target_table *__tgt_rtl_load_binary(int32_t device_id,
       DP("KernDesc: Version: %d\n", KernDescVal.Version);
       DP("KernDesc: TSize: %d\n", KernDescVal.TSize);
       DP("KernDesc: WG_Size: %d\n", KernDescVal.WG_Size);
+      DP("KernDesc: num_args: %d\n", KernDescVal.num_args);
       DP("KernDesc: Mode: %d\n", KernDescVal.Mode);
       DP("KernDesc: HostServices: %x\n", KernDescVal.HostServices);
       DP("KernDesc: MaxParallelLevel: %x\n", KernDescVal.MaxParallelLevel);


### PR DESCRIPTION
…o store number of kernel args.  Then use this when initializing the runtime to calculate kernel_segment_size to avoid the need for comgr.  Remove the commented out printf in system.cpp to show comgr kss vs kss calculated from clang generated symbol.  It is up to Jonathan if he wants to use this instead of messagepack.   However, this PR shows how to pull any information from the kern_desc structure after code object is frozen.   This PR also moves the definition of the structure into an impl header with a note to keep in sync with clang. 

This PR does not get rid of comgr yet.  To do that two things are necessary.  1 remove this call at line 1606.    
 err = get_code_object_custom_metadata(types[i], tmp_module, module_size, gpu);

2. replace with equivalent function using message pack OR have the KernelInfoTable entries initialized in the symbol iterator at line 1465. 