### PR TITLE
Revert back to using err_shared_var_init instead of warn_shared_init

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7961,9 +7961,8 @@ def err_cuda_device_exceptions : Error<
 def err_dynamic_var_init : Error<
     "dynamic initialization is not supported for "
     "__device__, __constant__, and __shared__ variables.">;
-def warn_shared_var_init : Warning<
-    "initialization is not supported for __shared__ variables.">,
-    InGroup<DiagGroup<"cuda-shared-init">>, DefaultError;
+def err_shared_var_init : Error<
+    "initialization is not supported for __shared__ variables.">;
 def err_device_static_local_var : Error<
     "within a %select{__device__|__global__|__host__|__host__ __device__}0 "
     "function, only __shared__ variables or const variables without device "

--- a/clang/lib/Sema/SemaCUDA.cpp
+++ b/clang/lib/Sema/SemaCUDA.cpp
@@ -516,7 +516,7 @@ void Sema::checkAllowedCUDAInitializer(VarDecl *VD) {
 
     if (!AllowedInit) {
       Diag(VD->getLocation(), VD->hasAttr<CUDASharedAttr>()
-                                  ? diag::warn_shared_var_init
+                                  ? diag::err_shared_var_init
                                   : diag::err_dynamic_var_init)
           << Init->getSourceRange();
       VD->setInvalidDecl();


### PR DESCRIPTION
Clean build of aomp, and testing shows zero issues.  
Makes us match upstream.