### PR TITLE
Implement malloc as hostcall, proof of concept

### DIFF
--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/memoryheap.cu
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/memoryheap.cu
@@ -44,7 +44,12 @@
 DEVICE char gpuHeap[SIZE_OF_HEAP];
 DEVICE uint32_t gpuFlags[NUM_PAGES];
 
+EXTERN char *  printf_alloc(uint32_t bufsz);
+
 DEVICE void *__malloc(size_t size) {
+
+  return printf_alloc(size);
+  
   char *heap = (char *)gpuHeap;
   if (size > SIZE_OF_HEAP) {
     return (void *)nullptr;
@@ -78,6 +83,8 @@ DEVICE void *__malloc(size_t size) {
 }
 
 DEVICE void __free(void *ptr) {
+  return;
+  
   if (ptr == nullptr) {
     return;
   }


### PR DESCRIPTION
We shouldn't commit this as-is, but it's interesting that it passes our testing. At least locally. We may want to commit a cleaned up version which actually frees the memory.

The advantage over the current implementation is correctness when multiple kernels call malloc simultaneously, the disadvantage is it'll be much slower.

Long term we should:
- Remove all uses of malloc from the runtime, as we always have more context than 'some heap'
- Write a malloc which uses infrequent hostcalls to get large blocks of memory and carves it up on the device in thread safe fashion