### PR TITLE
Use readcyclecounter instead of checking architecture version macro

### DIFF
--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/target_impl.hip
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/target_impl.hip
@@ -38,11 +38,11 @@ DEVICE __kmpc_impl_lanemask_t __kmpc_impl_lanemask_gt() {
 DEVICE double __kmpc_impl_get_wtick() { return ((double)1E-9); }
 
 DEVICE double __kmpc_impl_get_wtime() {
-#if __AMDGCN_MODEL__ > 800
-  uint64_t t = __builtin_amdgcn_s_memrealtime();
-#else
-  uint64_t t = __builtin_amdgcn_s_memtime();
-#endif
+  // This expands to s_memtime
+  // In the future, llc will hopefully expand it to s_memrealtime
+  // when that instruction is available
+  uint64_t t = __builtin_readcyclecounter();
+  // TODO: Check scaling factor - may be architecture specific
   return ((double)1.0 / 745000000.0) * t;
 }
 


### PR DESCRIPTION
The AMDGCN macro is causing some merge problems internally. This change loses functionality, as readcyclecounter currently never expands to the more accurate memrealtime, but the loss seems acceptable.

The right implementation of wtime needs to check for the presence of the s-memrealtime feature, and choose a scaling factor which may be architecture-specific. This should probably be implemented in llc, not in the openmp library.