### PR TITLE
Revert "Use readcyclecounter instead of checking architecture version macro"

### DIFF
--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/target_impl.hip
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/target_impl.hip
@@ -38,11 +38,11 @@ DEVICE __kmpc_impl_lanemask_t __kmpc_impl_lanemask_gt() {
 DEVICE double __kmpc_impl_get_wtick() { return ((double)1E-9); }
 
 DEVICE double __kmpc_impl_get_wtime() {
-  // This expands to s_memtime
-  // In the future, llc will hopefully expand it to s_memrealtime
-  // when that instruction is available
-  uint64_t t = __builtin_readcyclecounter();
-  // TODO: Check scaling factor - may be architecture specific
+#if __AMDGCN_MODEL__ > 800
+  uint64_t t = __builtin_amdgcn_s_memrealtime();
+#else
+  uint64_t t = __builtin_amdgcn_s_memtime();
+#endif
   return ((double)1.0 / 745000000.0) * t;
 }
 


### PR DESCRIPTION
Reverts ROCm-Developer-Tools/amd-llvm-project#55

Seems the schedule test depends on this. Can't look into that now.