### PR TITLE
Cleanup dead code as found by gerrit reviews

### DIFF
--- a/clang/lib/Basic/Cuda.cpp
+++ b/clang/lib/Basic/Cuda.cpp
@@ -165,26 +165,6 @@ CudaVersion MaxVersionForCudaArch(CudaArch A) {
   case CudaArch::SM_20:
   case CudaArch::SM_21:
     return CudaVersion::CUDA_80;
-  case CudaArch::GFX600:
-  case CudaArch::GFX601:
-  case CudaArch::GFX700:
-  case CudaArch::GFX701:
-  case CudaArch::GFX702:
-  case CudaArch::GFX703:
-  case CudaArch::GFX704:
-  case CudaArch::GFX801:
-  case CudaArch::GFX802:
-  case CudaArch::GFX803:
-  case CudaArch::GFX810:
-  case CudaArch::GFX900:
-  case CudaArch::GFX902:
-  case CudaArch::GFX904:
-  case CudaArch::GFX906:
-  case CudaArch::GFX909:
-  case CudaArch::GFX1010:
-  case CudaArch::GFX1011:
-  case CudaArch::GFX1012:
-    return CudaVersion::CUDA_90;
   default:
     return CudaVersion::LATEST;
   }

--- a/clang/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -1675,6 +1675,11 @@ llvm::Value *CGOpenMPRuntime::emitUpdateLocation(CodeGenFunction &CGF,
   // OpenMPLocThreadIDMap may have null DebugLoc and non-null ThreadID, if
   // GetOpenMPThreadID was called before this routine.
   if (!LocValue.isValid()) {
+   // AMDGCN does not handle static initializers of aggregate constants.
+   // compiling -g will excercise this path.
+   if (CGM.getTriple().getArch() == llvm::Triple::amdgcn)
+      return getOrCreateDefaultLocation(Flags).getPointer();
+
     // Generate "ident_t .kmpc_loc.addr;"
     Address AI = CGF.CreateMemTemp(IdentQTy, ".kmpc_loc.addr");
     auto &Elem = OpenMPLocThreadIDMap.FindAndConstruct(CGF.CurFn);

--- a/clang/lib/CodeGen/CGOpenMPRuntimeNVPTX.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntimeNVPTX.cpp
@@ -1246,13 +1246,10 @@ void CGOpenMPRuntimeNVPTX::GenerateMetaData(CodeGenModule &CGM,
   // Emitting Metadata for thread_limit causes an issue in ISEL, due to
   // an optimization in OPT.
   // See line 230 lib/Target/AMDGPU/AMDGPULowerKernelAttributes.cpp
-  bool enableMetaOptBug = false;
   bool flatAttrEmitted = false;
   int FlatAttr = 0;
   int DefaultWorkGroupSz =
       CGM.getTarget().getGridValue(GPU::GVIDX::GV_Default_WG_Size);
-  if (char *envStr = getenv("AMDGPU_ENABLE_META_OPT_BUG"))
-    enableMetaOptBug = atoi(envStr);
 
   if ((CGM.getTriple().getArch() == llvm::Triple::amdgcn) &&
       (isOpenMPTeamsDirective(D.getDirectiveKind()) ||
@@ -1293,9 +1290,8 @@ void CGOpenMPRuntimeNVPTX::GenerateMetaData(CodeGenModule &CGM,
               llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), 1)),
           llvm::ConstantAsMetadata::get(
               llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), 1))};
-      if (enableMetaOptBug)
-        OutlinedFn->setMetadata("reqd_work_group_size",
-                                llvm::MDNode::get(Ctx, AttrMDArgs));
+      OutlinedFn->setMetadata("reqd_work_group_size",
+                              llvm::MDNode::get(Ctx, AttrMDArgs));
       OutlinedFn->setMetadata("work_group_size_hint",
                               llvm::MDNode::get(Ctx, AttrMDArgs));
       std::string AttrVal = llvm::utostr(compileTimeThreadLimit);


### PR DESCRIPTION
removal of dead code as show by testing all aomp tests.
These were pointed out during the gerrit code reviews.
Testing reveals code does not trigger failures.