### PR TITLE
Greg and i discussed and decided to pull the __AMDGCN_MODEL__ definition

### DIFF
--- a/clang/lib/Basic/Targets/AMDGPU.cpp
+++ b/clang/lib/Basic/Targets/AMDGPU.cpp
@@ -343,9 +343,6 @@ void AMDGPUTargetInfo::getTargetDefines(const LangOptions &Opts,
     StringRef CanonName = isAMDGCN(getTriple()) ?
       getArchNameAMDGCN(GPUKind) : getArchNameR600(GPUKind);
     Builder.defineMacro(Twine("__") + Twine(CanonName) + Twine("__"));
-    // Make AMDGCN be a useful numeric value
-    Builder.defineMacro("__AMDGCN_MODEL__", CanonName.substr(3));
-
   }
 
   // TODO: __HAS_FMAF__, __HAS_LDEXPF__, __HAS_FP64__ are deprecated and will be

--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -2493,7 +2493,7 @@ public:
 #ifdef PACKAGE_VENDOR
     OS << PACKAGE_VENDOR << " ";
 #else
-    OS << "AOMP-11.5-1 (http://github.com/ROCm-Developer-Tools/aomp):\n Source ID:11.5-1-build_from_release_source\n  ";
+    OS << "LLVM (http://llvm.org/):\n  ";
 #endif
     OS << PACKAGE_NAME << " version " << PACKAGE_VERSION;
 #ifdef LLVM_VERSION_INFO

--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -2493,7 +2493,7 @@ public:
 #ifdef PACKAGE_VENDOR
     OS << PACKAGE_VENDOR << " ";
 #else
-    OS << "LLVM (http://llvm.org/):\n  ";
+    OS << "AOMP-11.5-1 (http://github.com/ROCm-Developer-Tools/aomp):\n Source ID:11.5-1-build_from_release_source\n  ";
 #endif
     OS << PACKAGE_NAME << " version " << PACKAGE_VERSION;
 #ifdef LLVM_VERSION_INFO

--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/target_impl.hip
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/target_impl.hip
@@ -38,10 +38,10 @@ DEVICE __kmpc_impl_lanemask_t __kmpc_impl_lanemask_gt() {
 DEVICE double __kmpc_impl_get_wtick() { return ((double)1E-9); }
 
 DEVICE double __kmpc_impl_get_wtime() {
-#if __AMDGCN_MODEL__ > 800
-  uint64_t t = __builtin_amdgcn_s_memrealtime();
-#else
+#if __gfx700__ || __gfx701__ || __gfx702__
   uint64_t t = __builtin_amdgcn_s_memtime();
+#else
+  uint64_t t = __builtin_amdgcn_s_memrealtime();
 #endif
   return ((double)1.0 / 745000000.0) * t;
 }


### PR DESCRIPTION
and any variant therein.  We are applying this same change to amd-stg-openmp
and modifying the runtime function to more simply test for gfx70[012].

need to remove CommandLine.cpp change ...