### PR TITLE
get rid of hostcall register functions.  Replace with handlePayload(s…

### DIFF
--- a/openmp/libomptarget/plugins/hsa/impl/atmi_hostcall.c
+++ b/openmp/libomptarget/plugins/hsa/impl/atmi_hostcall.c
@@ -139,8 +139,6 @@ hsa_status_t atmi_hostcall_version_check(unsigned int device_vrm) {
   return HSA_STATUS_SUCCESS;
 }
 
-void hostcall_register_all_handlers(amd_hostcall_consumer_t *c, void *cbdata);
-
 // These three external functions are called by atmi.
 // ATMI uses the header atmi_hostcall.h to reference these.
 //
@@ -152,8 +150,6 @@ unsigned long atmi_hostcall_assign_buffer(hsa_queue_t *this_Q,
     // May be the first call. Create consumer if so
     if (!atl_hcq_consumer) {
       atl_hcq_consumer = amd_hostcall_create_consumer();
-      // None of the handlers use the callback data at present
-      hostcall_register_all_handlers(atl_hcq_consumer, NULL);
       // Spawns a thread
       amd_hostcall_launch_consumer(atl_hcq_consumer);
     }

--- a/openmp/libomptarget/plugins/hsa/impl/hostcall_impl.h
+++ b/openmp/libomptarget/plugins/hsa/impl/hostcall_impl.h
@@ -2,7 +2,6 @@
 #define AMD_HOSTCALL_IMPL_H
 
 #include "amd_hostcall.h"
-#define WITH_HSA
 
 /** Opaque wrapper for signal */
 typedef struct {


### PR DESCRIPTION
…ervice, payload).  handlPayload has a simple switch to call the correct service handler function.

Jon, This is the next step in simplifying hostcall into hostrpc.  Eventually, I want to merge atmi_hostcall.c hostcall.cpp, and hostrpc_handlers.c into a single source called hostrpc.c.   The only externs will be the few routines that atmi calls. 