### PR TITLE
Ignore environment variable ATMI_DEPENDENCY_SYNC_TYPE, unused by openmp

### DIFF
--- a/openmp/libomptarget/plugins/hsa/impl/data.cpp
+++ b/openmp/libomptarget/plugins/hsa/impl/data.cpp
@@ -171,8 +171,6 @@ atmi_status_t Runtime::Memfree(void *ptr) {
   return ret;
 }
 
-
-
 atmi_status_t Runtime::Memcpy(void *dest, const void *src, size_t size) {
   atmi_status_t ret;
   hsa_status_t err;

--- a/openmp/libomptarget/plugins/hsa/impl/rt.h
+++ b/openmp/libomptarget/plugins/hsa/impl/rt.h
@@ -37,7 +37,6 @@ class Environment {
 
   void GetEnvAll();
 
-  int getDepSyncType() const { return dep_sync_type_; }
   int getMaxSignals() const { return max_signals_; }
   int getMaxQueueSize() const { return max_queue_size_; }
   int getMaxKernelTypes() const { return max_kernel_types_; }
@@ -58,7 +57,6 @@ class Environment {
     return ret;
   }
 
-  int dep_sync_type_;
   int max_signals_;
   int max_queue_size_;
   int max_kernel_types_;
@@ -114,7 +112,6 @@ class Runtime {
 
   // environment variables
   const Environment &getEnvironment() const { return env_; }
-  int getDepSyncType() const { return env_.getDepSyncType(); }
   int getMaxSignals() const { return env_.getMaxSignals(); }
   int getMaxQueueSize() const { return env_.getMaxQueueSize(); }
   int getMaxKernelTypes() const { return env_.getMaxKernelTypes(); }

--- a/openmp/libomptarget/plugins/hsa/impl/system.cpp
+++ b/openmp/libomptarget/plugins/hsa/impl/system.cpp
@@ -232,8 +232,7 @@ std::map<std::string, std::string> KernelNameMap;
 std::vector<std::map<std::string, atl_kernel_info_t> > KernelInfoTable;
 std::vector<std::map<std::string, atl_symbol_info_t> > SymbolInfoTable;
 
-static atl_dep_sync_t g_dep_sync_type =
-    (atl_dep_sync_t)core::Runtime::getInstance().getDepSyncType();
+static atl_dep_sync_t g_dep_sync_type = ATL_SYNC_CALLBACK;
 
 RealTimer SignalAddTimer("Signal Time");
 RealTimer HandleSignalTimer("Handle Signal Time");

--- a/openmp/libomptarget/plugins/hsa/impl/utils.cpp
+++ b/openmp/libomptarget/plugins/hsa/impl/utils.cpp
@@ -147,10 +147,7 @@ namespace core {
 void Environment::GetEnvAll() {
   std::string var = GetEnv("ATMI_HELP");
   if (!var.empty()) {
-    std::cout << "ATMI_DEPENDENCY_SYNC_TYPE : ATMI_SYNC_CALLBACK "
-                 "ATMI_SYNC_BARRIER_PKT"
-              << std::endl
-              << "ATMI_MAX_HSA_SIGNALS : positive integer" << std::endl
+    std::cout << "ATMI_MAX_HSA_SIGNALS : positive integer" << std::endl
               << "ATMI_MAX_HSA_QUEUE_SIZE : positive integer" << std::endl
               << "ATMI_MAX_KERNEL_TYPES : positive integer" << std::endl
               << "ATMI_DEVICE_GPU_WORKERS : positive integer" << std::endl
@@ -158,15 +155,6 @@ void Environment::GetEnvAll() {
               << "ATMI_DEBUG : 1 for printing out trace/debug info" << std::endl
               << "ATMI_PROFILE : 1 for printing out timer info" << std::endl;
     exit(0);
-  }
-
-  var = GetEnv("ATMI_DEPENDENCY_SYNC_TYPE");
-  // default dependency type: callback; switch the if-else checks to change the
-  // defaults
-  if (var.empty() || var == "ATMI_SYNC_CALLBACK") {
-    dep_sync_type_ = ATL_SYNC_CALLBACK;
-  } else if (var == "ATMI_SYNC_BARRIER_PKT") {
-    dep_sync_type_ = ATL_SYNC_BARRIER_PKT;
   }
 
   var = GetEnv("ATMI_MAX_HSA_SIGNALS");


### PR DESCRIPTION
There's no reference to this environment variable outside of ATMI. Explicitly using the default is a step towards taskgroup being dead.