### PR TITLE
Skip empty modules to avoid linker warning.

### DIFF
--- a/clang/tools/clang-hip/clang-build-select-link/ClangBuildSelectLink.cpp
+++ b/clang/tools/clang-hip/clang-build-select-link/ClangBuildSelectLink.cpp
@@ -150,9 +150,11 @@ static bool loadArFile(const char *argv0, const std::string ArchiveName,
       }
       if (Verbose)
         errs() << "Linking member '" << goodname << "' of archive library.\n";
-      bool Err = L.linkInModule(std::move(M), ApplicableFlags);
-      if (Err)
-        return false;
+      if (M.get()->getTargetTriple() != "") {
+        bool Err = L.linkInModule(std::move(M), ApplicableFlags);
+        if (Err)
+          return false;
+      }
       ApplicableFlags = OrigFlags;
     } // end for each child
     failIfError(std::move(Err));
@@ -205,9 +207,11 @@ static bool linkFiles(const char *argv0, LLVMContext &Context, Linker &L,
       }
       if (Verbose)
         errs() << "Linking bc File'" << File << "' to module.\n";
-      bool Err = L.linkInModule(std::move(M), ApplicableFlags);
-      if (Err)
-        return false;
+      if (M.get()->getTargetTriple() != "") {
+        bool Err = L.linkInModule(std::move(M), ApplicableFlags);
+        if (Err)
+          return false;
+      }
     }
     // All linker flags apply to linking of subsequent files.
     ApplicableFlags = Flags;


### PR DESCRIPTION
I don't know of a better way to check if a module is empty, maybe someone else does?

I noticed these kinds of warnings when compiling a larger example. We can get these empty modules from archives which do not contain any device code, and extract an empty archive for the device.
