### PR TITLE
Moved strlen_max function inside the declare target #ifdef _DEVICE_GP…

### DIFF
--- a/openmp/libomptarget/hostrpc/src/hostrpc.cpp
+++ b/openmp/libomptarget/hostrpc/src/hostrpc.cpp
@@ -162,6 +162,16 @@ EXTERN int vector_product_zeros(int N, int *A, int *B, int *C) {
   return num_zeros;
 }
 
+// This utility is used for printf arguments that are variable length strings
+// The clang compiler will generate calls to this only when a string length is
+// not a compile time constant.
+EXTERN uint32_t __strlen_max(char *instr, uint32_t maxstrlen) {
+  for (uint32_t i = 0; i < maxstrlen; i++)
+    if (instr[i] == (char)0)
+      return (uint32_t)(i + 1);
+  return maxstrlen;
+}
+
 // ---------------------------------------------------
 #else
 // ---------------------------------------------------
@@ -252,16 +262,6 @@ EXTERN int global_free(char *ptr) {
   printf("HOST FALLBACK EXECUTION OF global_free not yet implemented\n");
   return 0;
 }
+
 #endif
 #pragma omp end declare target
-// ---------------------------------------------------
-
-// This utility is used for printf arguments that are variable length strings
-// The clang compiler will generate calls to this only when a string length is
-// not a compile time constant.
-EXTERN uint32_t __strlen_max(char *instr, uint32_t maxstrlen) {
-  for (uint32_t i = 0; i < maxstrlen; i++)
-    if (instr[i] == (char)0)
-      return (uint32_t)(i + 1);
-  return maxstrlen;
-}


### PR DESCRIPTION
…U to resolve linker failure seen in pfspecifier_str smoke test.

Greg originally had this outside of the declare target region, so I was curious to see if this solution is acceptable.