### PR TITLE
Specialise register module to only call site

### DIFF
--- a/openmp/libomptarget/plugins/hsa/impl/atmi.cpp
+++ b/openmp/libomptarget/plugins/hsa/impl/atmi.cpp
@@ -25,11 +25,11 @@ atmi_machine_t *atmi_machine_get_info() {
 /*
  * Modules
  */
-atmi_status_t atmi_module_register_from_memory_to_place(
-    void **modules, size_t *module_sizes, atmi_platform_type_t *types,
-    const int num_modules, atmi_place_t place) {
+atmi_status_t atmi_module_register_from_memory_to_place(void *module_bytes,
+                                                        size_t module_size,
+                                                        atmi_place_t place) {
   return core::Runtime::getInstance().RegisterModuleFromMemory(
-      modules, module_sizes, types, num_modules, place);
+      module_bytes, module_size, place);
 }
 
 /*

--- a/openmp/libomptarget/plugins/hsa/impl/atmi_runtime.h
+++ b/openmp/libomptarget/plugins/hsa/impl/atmi_runtime.h
@@ -75,18 +75,10 @@ atmi_status_t atmi_finalize();
  * hand, CPU devices execute regular x86 functions that are compiled with the
  * host program.
  *
- * @param[in] modules A collection of memory regions that contain the GPU
- * modules
+ * @param[in] module_bytes A memory region that contains the GPU modules
  * targeting ::AMDGCN platform types. Value cannot be NULL.
  *
- * @param[in] module_sizes Sizes of each module region in @p modules. Value
- * cannot be NULL.
- *
- * @param[in] types A collection of platform types corresponding to the modules.
- * Value cannot be NULL.
- *
- * @param[in] num_modules Size of @p modules. @p module_sizes and @p types.
- * Value should be greater than 0.
+ * @param[in] module_size Size of module region
  *
  * @param[in] place Denotes the execution place (device) on which the module
  * should be registered and loaded.
@@ -98,9 +90,9 @@ atmi_status_t atmi_finalize();
  * @retval ::ATMI_STATUS_UNKNOWN The function encountered errors.
  *
  */
-atmi_status_t atmi_module_register_from_memory_to_place(
-    void **modules, size_t *module_sizes, atmi_platform_type_t *types,
-    const int num_modules, atmi_place_t place);
+  atmi_status_t atmi_module_register_from_memory_to_place(void *module_bytes,
+                                                        size_t module_size,
+                                                        atmi_place_t place);
 
 /** @} */
 

--- a/openmp/libomptarget/plugins/hsa/impl/rt.h
+++ b/openmp/libomptarget/plugins/hsa/impl/rt.h
@@ -79,8 +79,7 @@ class Runtime {
   // machine info
   atmi_machine_t *GetMachineInfo();
   // modules
-  atmi_status_t RegisterModuleFromMemory(void **, size_t *,
-                                         atmi_platform_type_t *, const int,
+  atmi_status_t RegisterModuleFromMemory(void *, size_t,
                                          atmi_place_t);
   // kernels
   virtual atmi_status_t CreateKernel(atmi_kernel_t *, const int, const size_t *,

--- a/openmp/libomptarget/plugins/hsa/src/rtl.cpp
+++ b/openmp/libomptarget/plugins/hsa/src/rtl.cpp
@@ -565,9 +565,8 @@ __tgt_target_table *__tgt_rtl_load_binary(int32_t device_id,
 
   atmi_status_t err;
   {
-    atmi_platform_type_t platform = AMDGCN;
     err = atmi_module_register_from_memory_to_place(
-        (void **)&image->ImageStart, &img_size, &platform, 1, get_gpu_place(device_id));
+        (void *)image->ImageStart, img_size, get_gpu_place(device_id));
 
     check("Module registering", err);
     if (err != ATMI_STATUS_SUCCESS) {


### PR DESCRIPTION
rtl.cpp is the only user of register_from_memory and makes only one call to it. Specialise on:
- Always passes platform == AMDGCN
- Passed an array of length one, replaced with scalar
- Never passes negative device_id (plus covered by pre-existing assert in rtl.cpp)
- get_code_object_custom_metadata doesn't mutate the passed bytes (it's the msgpack reader), skip a malloc
- No need to check for duplicate symbols in a single shared object, removes many heap allocations

Non functional change.