### PR TITLE
Specialise atmi_kernel_create on rtl call site

### DIFF
--- a/openmp/libomptarget/plugins/hsa/impl/atmi.cpp
+++ b/openmp/libomptarget/plugins/hsa/impl/atmi.cpp
@@ -36,13 +36,9 @@ atmi_status_t atmi_module_register_from_memory_to_place(void *module_bytes,
  * Kernels
  */
 atmi_status_t atmi_kernel_create(atmi_kernel_t *atmi_kernel, const int num_args,
-                                 const size_t *arg_sizes, const int num_impls,
-                                 ...) {
-  va_list arguments;
-  va_start(arguments, num_impls);
-  return core::Runtime::getInstance().CreateKernel(
-      atmi_kernel, num_args, arg_sizes, num_impls, arguments);
-  va_end(arguments);
+                                 const size_t *arg_sizes, const char *name) {
+  return core::Runtime::getInstance().CreateKernel(atmi_kernel, num_args,
+                                                   arg_sizes, name);
 }
 
 atmi_status_t atmi_kernel_release(atmi_kernel_t atmi_kernel) {

--- a/openmp/libomptarget/plugins/hsa/impl/atmi_runtime.h
+++ b/openmp/libomptarget/plugins/hsa/impl/atmi_runtime.h
@@ -163,9 +163,7 @@ typedef struct atmi_kernel_s {
  *
  * @param[in] num_impls Number of implementations for this kernel.
  *
- * @param[in] ... va_list Key-value pairs separated by commas of the format
- * (@atmi_devtype_t, implementation), where implementation is either the char
- * string for GPU implementation or function pointer for CPU implementation.
+ * @param[in] name Hsaco name of this kernel
  *
  * @retval ::ATMI_STATUS_SUCCESS The function has executed successfully.
  *
@@ -175,8 +173,8 @@ typedef struct atmi_kernel_s {
  *
  */
 atmi_status_t atmi_kernel_create(atmi_kernel_t *atmi_kernel, const int num_args,
-                                 const size_t *arg_sizes, const int num_impls,
-                                 ...);
+                                 const size_t *arg_sizes,
+                                 const char * name);
 /**
  * @brief Create an empty kernel opaque structure.
  *

--- a/openmp/libomptarget/plugins/hsa/impl/rt.h
+++ b/openmp/libomptarget/plugins/hsa/impl/rt.h
@@ -83,7 +83,7 @@ class Runtime {
                                          atmi_place_t);
   // kernels
   virtual atmi_status_t CreateKernel(atmi_kernel_t *, const int, const size_t *,
-                                     const int, va_list);
+                                     const char *);
   virtual atmi_status_t ReleaseKernel(atmi_kernel_t);
   atmi_status_t CreateEmptyKernel(atmi_kernel_t *, const int, const size_t *);
   atmi_status_t AddGPUKernelImpl(atmi_kernel_t, const char *,

--- a/openmp/libomptarget/plugins/hsa/src/rtl.cpp
+++ b/openmp/libomptarget/plugins/hsa/src/rtl.cpp
@@ -667,8 +667,8 @@ __tgt_target_table *__tgt_rtl_load_binary(int32_t device_id,
       *it = sizeof(void *);
     }
 
-    atmi_status_t stat = atmi_kernel_create(&kernel, arg_num, &arg_sizes[0], 1,
-                                            ATMI_DEVTYPE_GPU, e->name);
+    atmi_status_t stat = atmi_kernel_create(&kernel, arg_num, &arg_sizes[0],
+                                            e->name);
 
     if (stat != ATMI_STATUS_SUCCESS) {
       DP("atmi_kernel_create failed %d\n", stat);


### PR DESCRIPTION
Specialise atmi_kernel_create
- Replace variadic functions with explicitly typed
- Specialise on number implementations == 1
- Specialise on devtype == AMDGPU