### PR TITLE
Elide an atmi call, drive by fixes

### DIFF
--- a/openmp/libomptarget/hostrpc/services/hostrpc_execute_service.c
+++ b/openmp/libomptarget/hostrpc/services/hostrpc_execute_service.c
@@ -32,6 +32,7 @@ SOFTWARE.
 #include "hostrpc_internal.h"
 #include <ctype.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/openmp/libomptarget/hostrpc/services/hostrpc_externs.c
+++ b/openmp/libomptarget/hostrpc/services/hostrpc_externs.c
@@ -105,8 +105,9 @@ static buffer_t *atl_hcq_create_buffer(unsigned int num_packets) {
 
 // The following  three external functions are called by plugin.
 //
-unsigned long hostrpc_assign_buffer(hsa_queue_t *this_Q,
-                                          uint32_t device_id) {
+unsigned long hostrpc_assign_buffer(hsa_agent_t agent,
+                                    hsa_queue_t *this_Q,
+                                    uint32_t device_id) {
   atl_hcq_element_t *llq_elem;
   llq_elem = atl_hcq_find_by_hsa_q(this_Q);
   if (!llq_elem) {
@@ -117,12 +118,7 @@ unsigned long hostrpc_assign_buffer(hsa_queue_t *this_Q,
       amd_hostcall_launch_consumer(atl_hcq_consumer);
     }
 
-    hsa_agent_t agent;
-    atmi_place_t place = ATMI_PLACE_GPU(0, device_id);
     // FIXME: error check for this function
-    // atmi_status_t atmi_err =
-    atmi_interop_hsa_get_agent(place, &agent);
-    // ATMIErrorCheck(Could not get agent from place, atmi_err);
     uint32_t numCu;
     // hsa_status_t err =
     hsa_agent_get_info(

--- a/openmp/libomptarget/hostrpc/services/hostrpc_internal.h
+++ b/openmp/libomptarget/hostrpc/services/hostrpc_internal.h
@@ -205,7 +205,7 @@ typedef struct {
     uint32_t index_size;
 } buffer_t;
 
-#include "../../plugins/hsa/impl/atmi_interop_hsa.h"
+#include "../../plugins/hsa/impl/atmi_runtime.h"
 
 #ifdef __cplusplus
 } // extern "C"

--- a/openmp/libomptarget/plugins/hsa/src/rtl.cpp
+++ b/openmp/libomptarget/plugins/hsa/src/rtl.cpp
@@ -31,7 +31,9 @@
 #include "atmi_runtime.h"
 
 // hostrpc interface, FIXME: consider moving to its own include
-extern "C" unsigned long hostrpc_assign_buffer(hsa_queue_t * this_Q, uint32_t device_id);
+extern "C" unsigned long hostrpc_assign_buffer(hsa_agent_t agent,
+                                               hsa_queue_t *this_Q,
+                                               uint32_t device_id);
 extern "C" hsa_status_t hostrpc_init();
 extern "C" hsa_status_t hostrpc_terminate();
 
@@ -572,7 +574,7 @@ int32_t __tgt_rtl_init_device(int device_id) {
   // this is per device id init
   DP("Initialize the device id: %d\n", device_id);
 
-  hsa_agent_t &agent = DeviceInfo.HSAAgents[device_id];
+  hsa_agent_t agent = DeviceInfo.HSAAgents[device_id];
 
   // Get number of Compute Unit
   uint32_t compute_units = 0;
@@ -835,7 +837,7 @@ __tgt_target_table *__tgt_rtl_load_binary(int32_t device_id,
     check("Module registering", err);
     if (err != ATMI_STATUS_SUCCESS) {
       char GPUName[64] = "--unknown gpu--";
-      hsa_agent_t &agent = DeviceInfo.HSAAgents[device_id];
+      hsa_agent_t agent = DeviceInfo.HSAAgents[device_id];
       (void)hsa_agent_get_info(agent, (hsa_agent_info_t)HSA_AGENT_INFO_NAME,
                                (void *)GPUName);
       fprintf(stderr,
@@ -1546,8 +1548,8 @@ int32_t __tgt_rtl_run_target_team_region(int32_t device_id, void *tgt_entry_ptr,
       // assign a hostcall buffer for the selected Q
       if (g_atmi_hostcall_required) {
         {
-          impl_args->hostcall_ptr =
-              hostrpc_assign_buffer(queue, device_id);
+          impl_args->hostcall_ptr = hostrpc_assign_buffer(
+              DeviceInfo.HSAAgents[device_id], queue, device_id);
         }
       }
 


### PR DESCRIPTION
Hostrpc services has some remaining hooks into atmi. This removes one of them.

Also replaces some references to uint64_t with value copy, adds a missing stdbool header. Can now use a more specific atmi header.

Remaining uses are of atmi_malloc and atmi_free (and the SERVICE_DEMO uses atmi_memcpy). 
