### PR TITLE
Claim to be hip when compiling openmp for amdgcn. Similar to the cuda…

### DIFF
--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -4246,11 +4246,11 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     if (getTarget().getTriple().isNVPTX())
       return EmitNVPTXDevicePrintfCallExpr(E, ReturnValue);
     if (getTarget().getTriple().isAMDGCN()) {
-      if (getLangOpts().HIP)
-        return EmitAMDGPUDevicePrintfCallExpr(E, ReturnValue);
-      else if (getLangOpts().OpenMP)
+      if (getLangOpts().OpenMP)
         return EmitHostrpcVargsFn(E, "printf_allocate", "printf_execute",
                                   ReturnValue);
+      else if (getLangOpts().HIP)
+        return EmitAMDGPUDevicePrintfCallExpr(E, ReturnValue);
     }
     break;
   case Builtin::BI__builtin_canonicalize:

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -3097,6 +3097,12 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
 
   // Check if -fopenmp is specified and set default version to 5.0.
   Opts.OpenMP = Args.hasArg(options::OPT_fopenmp) ? 50 : 0;
+
+  if (Opts.OpenMP && T.isAMDGCN()) {
+    // Claim to be HIP.
+    Opts.HIP = 1;
+  }
+
   // Check if -fopenmp-simd is specified.
   bool IsSimdSpecified =
       Args.hasFlag(options::OPT_fopenmp_simd, options::OPT_fno_openmp_simd,

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -472,7 +472,7 @@ static void InitializeStandardPredefinedMacros(const TargetInfo &TI,
     Builder.defineMacro("__ASSEMBLER__");
   if (LangOpts.CUDA && !LangOpts.HIP)
     Builder.defineMacro("__CUDA__");
-  if (LangOpts.HIP) {
+  if (LangOpts.HIP && !LangOpts.OpenMP) {
     Builder.defineMacro("__HIP__");
     Builder.defineMacro("__HIPCC__");
     if (LangOpts.CUDAIsDevice)


### PR DESCRIPTION
…/openmp relationship. Haven't thought through the consequences. This patch is for discussion, not for committing.

Part of debugging why CUDA_ARCH is set for openmp compilation on amdgcn.

There are other places that need to be fixed up if going down this path. E.g. getLangOpts().HIP is used to set uniform-work-group-size to true, which we probably don't want on OpenMP.

I think OpenMP on nvptx essentially claims to be cuda. Hip also sets some of the cuda related options in clang. OpenMP on amdgcn can claim to be hip, and optionally also claim to be cuda.

This feels like debt - hip should not be implemented in terms of cuda, and I'm not confident openmp should be implemented in terms of either.
