### PR TITLE
Jc variant libm

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -1169,21 +1169,24 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
 
   // If we are offloading to a target via OpenMP we need to include the
   // openmp_wrappers folder which contains alternative system headers.
-  if (JA.isDeviceOffloading(Action::OFK_OpenMP) &&
-      getToolChain().getTriple().isNVPTX()){
-    if (!Args.hasArg(options::OPT_nobuiltininc)) {
-      // Add openmp_wrappers/* to our system include path.  This lets us wrap
-      // standard library headers.
-      SmallString<128> P(D.ResourceDir);
-      llvm::sys::path::append(P, "include");
-      llvm::sys::path::append(P, "openmp_wrappers");
-      CmdArgs.push_back("-internal-isystem");
-      CmdArgs.push_back(Args.MakeArgString(P));
-    }
+  if (JA.isDeviceOffloading(Action::OFK_OpenMP)) {
+    const llvm::Triple &T = getToolChain().getTriple();
+    if (T.isNVPTX() || T.isAMDGCN()) {
+      if (!Args.hasArg(options::OPT_nobuiltininc)) {
+        // Add openmp_wrappers/* to our system include path.  This lets us wrap
+        // standard library headers.
+        SmallString<128> P(D.ResourceDir);
+        llvm::sys::path::append(P, "include");
+        llvm::sys::path::append(P, "openmp_wrappers");
+        CmdArgs.push_back("-internal-isystem");
+        CmdArgs.push_back(Args.MakeArgString(P));
+      }
 
-    CmdArgs.push_back("-include");
-    CmdArgs.push_back("__clang_openmp_device_functions.h");
+      CmdArgs.push_back("-include");
+      CmdArgs.push_back("__clang_openmp_device_functions.h");
+    }
   }
+
   if (Args.hasFlag(options::OPT_fopenmp, options::OPT_fopenmp_EQ,
                    options::OPT_fno_openmp, false)){
     CmdArgs.push_back("-I");

--- a/clang/lib/Headers/__clang_cuda_cmath.h
+++ b/clang/lib/Headers/__clang_cuda_cmath.h
@@ -8,9 +8,6 @@
  */
 #ifndef __CLANG_CUDA_CMATH_H__
 #define __CLANG_CUDA_CMATH_H__
-#ifndef __CUDA__
-#error "This file is for CUDA compilation only."
-#endif
 
 #ifndef _OPENMP
 #include <limits>
@@ -128,6 +125,11 @@ __DEVICE__ float modf(float __x, float *__iptr) { return ::modff(__x, __iptr); }
 __DEVICE__ float pow(float __base, float __exp) {
   return ::powf(__base, __exp);
 }
+
+#if defined(__NVPTX__)
+// defines these in terms of functions in __clang_cuda_device_functions
+// signbit is nonstandard
+// pow is standard until c++11, but changes type in c++11. leave it for now.
 __DEVICE__ float pow(float __base, int __iexp) {
   return ::powif(__base, __iexp);
 }
@@ -136,6 +138,8 @@ __DEVICE__ double pow(double __base, int __iexp) {
 }
 __DEVICE__ bool signbit(float __x) { return ::__signbitf(__x); }
 __DEVICE__ bool signbit(double __x) { return ::__signbitd(__x); }
+#endif
+
 __DEVICE__ float sin(float __x) { return ::sinf(__x); }
 __DEVICE__ float sinh(float __x) { return ::sinhf(__x); }
 __DEVICE__ float sqrt(float __x) { return ::sqrtf(__x); }

--- a/clang/lib/Headers/__clang_cuda_math_forward_declares.h
+++ b/clang/lib/Headers/__clang_cuda_math_forward_declares.h
@@ -6,6 +6,10 @@
  *
  *===-----------------------------------------------------------------------===
  */
+
+// This gets included by math.h and by hip runtime
+
+
 #ifndef __CLANG__CUDA_MATH_FORWARD_DECLARES_H__
 #define __CLANG__CUDA_MATH_FORWARD_DECLARES_H__
 #if !defined(__CUDA__) && !__HIP__

--- a/clang/lib/Headers/__clang_hip_libdevice_declares.h
+++ b/clang/lib/Headers/__clang_hip_libdevice_declares.h
@@ -10,7 +10,11 @@
 #ifndef __CLANG_HIP_LIBDEVICE_DECLARES_H__
 #define __CLANG_HIP_LIBDEVICE_DECLARES_H__
 
+#ifdef __cplusplus
 extern "C" {
+#else
+#include <stdbool.h>
+#endif
 
 // BEGIN FLOAT
 __device__ __attribute__((const)) float __ocml_acos_f32(float);
@@ -313,7 +317,8 @@ __device__ __attribute__((pure)) __2f16 __ocml_log2_2f16(__2f16);
 __device__ inline __2f16
 __llvm_amdgcn_rcp_2f16(__2f16 __x) // Not currently exposed by ROCDL.
 {
-  return __2f16{__llvm_amdgcn_rcp_f16(__x.x), __llvm_amdgcn_rcp_f16(__x.y)};
+  // Needed parens for __2f16 from c, should also make it static
+  return (__2f16){__llvm_amdgcn_rcp_f16(__x.x), __llvm_amdgcn_rcp_f16(__x.y)};
 }
 __device__ __attribute__((const)) __2f16 __ocml_rint_2f16(__2f16);
 __device__ __attribute__((const)) __2f16 __ocml_rsqrt_2f16(__2f16);
@@ -321,6 +326,8 @@ __device__ __2f16 __ocml_sin_2f16(__2f16);
 __device__ __attribute__((const)) __2f16 __ocml_sqrt_2f16(__2f16);
 __device__ __attribute__((const)) __2f16 __ocml_trunc_2f16(__2f16);
 
+#ifdef __cplusplus
 } // extern "C"
+#endif
 
 #endif // __CLANG_HIP_LIBDEVICE_DECLARES_H__

--- a/clang/lib/Headers/__clang_hip_math.h
+++ b/clang/lib/Headers/__clang_hip_math.h
@@ -10,8 +10,14 @@
 #ifndef __CLANG_HIP_MATH_H__
 #define __CLANG_HIP_MATH_H__
 
+#ifdef _OPENMP_TARGET
+#error ""
+#endif
+#define _OPENMP_TARGET (defined(_OPENMP) && defined(__AMDGCN__))
+
 #include <limits.h>
-#ifndef _OPENMP
+#if !_OPENMP_TARGET
+#include <algorithm> // std::min
 #include <limits>
 #endif
 #include <stdint.h>
@@ -25,8 +31,8 @@
 #pragma push_macro("__RETURN_TYPE")
 
 // to be consistent with __clang_cuda_math_forward_declares
-#ifdef _OPENMP
-  #define __DEVICE__ static __attribute__((always_inline, nothrow))
+#if _OPENMP_TARGET
+  #define __DEVICE__ __attribute__((always_inline, nothrow))
 #else
   #define __DEVICE__ static __device__
 #endif
@@ -194,7 +200,7 @@ __DEVICE__
 inline int ilogbf(float __x) { return __ocml_ilogb_f32(__x); }
 // glibc defines isfinite,.. as a macro, exapnding in terms of __MATH_TG
 // if this is avoided with (isfinite), collides with glibc mathcalls.h
-#ifndef _OPENMP
+#if !_OPENMP_TARGET
 __DEVICE__
 inline __RETURN_TYPE isfinite(float __x) { return __ocml_isfinite_f32(__x); }
 __DEVICE__
@@ -365,7 +371,7 @@ inline float scalblnf(float __x, long int __n) {
 __DEVICE__
 inline float scalbnf(float __x, int __n) { return __ocml_scalbn_f32(__x, __n); }
 
-#ifndef _OPENMP
+#if !_OPENMP_TARGET
 __DEVICE__
 inline __RETURN_TYPE signbit(float __x) { return __ocml_signbit_f32(__x); }
 #endif
@@ -660,7 +666,7 @@ inline double hypot(double __x, double __y) {
 }
 __DEVICE__
 inline int ilogb(double __x) { return __ocml_ilogb_f64(__x); }
-#ifndef _OPENMP
+#if !_OPENMP_TARGET
 __DEVICE__
 inline __RETURN_TYPE isfinite(double __x) { return __ocml_isfinite_f64(__x); }
 __DEVICE__
@@ -838,7 +844,7 @@ __DEVICE__
 inline double scalbn(double __x, int __n) {
   return __ocml_scalbn_f64(__x, __n);
 }
-#ifndef _OPENMP
+#if !_OPENMP_TARGET
 __DEVICE__
 inline __RETURN_TYPE signbit(double __x) { return __ocml_signbit_f64(__x); }
 #endif
@@ -1035,7 +1041,7 @@ inline long long abs(long long __x) { return llabs(__x); }
 #endif
 // END INTEGER
 
-#ifndef _OPENMP
+#if !_OPENMP_TARGET
 __DEVICE__
 inline _Float16 fma(_Float16 __x, _Float16 __y, _Float16 __z) {
   return __ocml_fma_f16(__x, __y, __z);

--- a/clang/lib/Headers/__clang_hip_runtime_wrapper.h
+++ b/clang/lib/Headers/__clang_hip_runtime_wrapper.h
@@ -46,13 +46,16 @@ static inline __device__ void *free(void *__ptr) {
 }
 #endif
 
+#if !(defined(_OPENMP) && defined(__AMDGCN__))
 #include <__clang_hip_libdevice_declares.h>
 #include <__clang_hip_math.h>
+#endif
 
 #if !_OPENMP || __HIP_ENABLE_CUDA_WRAPPER_FOR_OPENMP__
+#if !(defined(_OPENMP) && defined(__AMDGCN__))
 #include <__clang_cuda_math_forward_declares.h>
 #include <__clang_cuda_complex_builtins.h>
-
+#endif
 #include <algorithm>
 #include <complex>
 #include <new>

--- a/clang/lib/Headers/openmp_wrappers/cmath
+++ b/clang/lib/Headers/openmp_wrappers/cmath
@@ -25,11 +25,10 @@
 #include <cstdlib>
 
 #pragma omp begin declare variant match(                                       \
-    device = {arch(nvptx, nvptx64)}, implementation = {extension(match_any)})
+    device = {arch(nvptx, nvptx64, amdgcn)},                                   \
+    implementation = {extension(match_any)})
 
-#define __CUDA__
 #include <__clang_cuda_cmath.h>
-#undef __CUDA__
 
 // Overloads not provided by the CUDA wrappers but by the CUDA system headers.
 // Since we do not include the latter we define them ourselves.

--- a/clang/lib/Headers/openmp_wrappers/complex
+++ b/clang/lib/Headers/openmp_wrappers/complex
@@ -14,11 +14,13 @@
 #error "This file is for OpenMP compilation only."
 #endif
 
+#if defined(__NVPTX__)
 // We require std::math functions in the complex builtins below.
 #include <cmath>
 
 #define __CUDA__
 #include <__clang_cuda_complex_builtins.h>
+#endif
 #endif
 
 // Grab the host header too.

--- a/clang/lib/Headers/openmp_wrappers/complex.h
+++ b/clang/lib/Headers/openmp_wrappers/complex.h
@@ -14,11 +14,13 @@
 #error "This file is for OpenMP compilation only."
 #endif
 
+#if defined(__NVPTX__)
 // We require math functions in the complex builtins below.
 #include <math.h>
 
 #define __CUDA__
 #include <__clang_cuda_complex_builtins.h>
+#endif
 #endif
 
 // Grab the host header too.

--- a/clang/lib/Headers/openmp_wrappers/math.h
+++ b/clang/lib/Headers/openmp_wrappers/math.h
@@ -46,4 +46,18 @@
 
 #pragma omp end declare variant
 
+#pragma omp begin declare variant match(                                       \
+    device = {arch(amdgcn)}, implementation = {extension(match_any)})
+
+#if defined (__device__)
+#error "__device__ already a macro, will need to push/pop it"
+#endif
+#define __device__
+#include <__clang_hip_libdevice_declares.h>
+#undef __device__
+
+#include <__clang_hip_math.h>
+  
+#pragma omp end declare variant
+
 #endif

--- a/clang/lib/Headers/openmp_wrappers/math.h
+++ b/clang/lib/Headers/openmp_wrappers/math.h
@@ -46,6 +46,9 @@
 
 #pragma omp end declare variant
 
+// This may be active for hip + host openmp, though it shouldn't be
+
+#if (defined(_OPENMP) && defined(__AMDGCN__))
 #pragma omp begin declare variant match(                                       \
     device = {arch(amdgcn)}, implementation = {extension(match_any)})
 
@@ -59,5 +62,6 @@
 #include <__clang_hip_math.h>
   
 #pragma omp end declare variant
+#endif
 
 #endif


### PR DESCRIPTION
This approximates a bring up of libm via variant for openmp on amdgcn. Some debugging code left in, posting the PR to avoid losing track of the WIP. This passes most, but not all of our tests. modf fails with a memory fault, one of the hip/openmp ones fails to compile.

powif has been implemented for hip in upstream.

The _OPENMP macro which doesn't work to distinguish target compilation has been replaced in upstream by _OPENMP_NVPTX, set manually. That's the right approach for amdgcn as well.

Converting the hip headers to be more easily used from C is largely at https://reviews.llvm.org/D84476

Plan is to wait for the merge from upstream to get through amd-stg-open and into amd-stg-openmp and cherry pick D84476, then reconstruct this patch on the result.