### PR TITLE
Copy device_environment data before loading onto gpu

### DIFF
--- a/openmp/libomptarget/deviceRTLs/common/src/omp_data.cu
+++ b/openmp/libomptarget/deviceRTLs/common/src/omp_data.cu
@@ -17,6 +17,11 @@
 // global device environment
 ////////////////////////////////////////////////////////////////////////////////
 
+#ifdef __AMDGCN__
+// Keeping the variable out of bss allows it to be initialized before
+// loading the device image
+__attribute__((section(".data")))
+#endif
 DEVICE omptarget_device_environmentTy omptarget_device_environment;
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/openmp/libomptarget/plugins/hsa/impl/atmi.cpp
+++ b/openmp/libomptarget/plugins/hsa/impl/atmi.cpp
@@ -25,13 +25,14 @@ atmi_machine_t *atmi_machine_get_info() {
 /*
  * Modules
  */
-atmi_status_t atmi_module_register_from_memory_to_place(void *module_bytes,
-                                                        size_t module_size,
-                                                        atmi_place_t place) {
+atmi_status_t atmi_module_register_from_memory_to_place(
+    void *module_bytes, size_t module_size, atmi_place_t place,
+    atmi_status_t (*on_deserialized_data)(void *data, size_t size,
+                                          void *cb_state),
+    void *cb_state) {
   return core::Runtime::getInstance().RegisterModuleFromMemory(
-      module_bytes, module_size, place);
+      module_bytes, module_size, place, on_deserialized_data, cb_state);
 }
-
 
 /*
  * Data

--- a/openmp/libomptarget/plugins/hsa/impl/atmi_runtime.h
+++ b/openmp/libomptarget/plugins/hsa/impl/atmi_runtime.h
@@ -71,6 +71,11 @@ atmi_status_t atmi_finalize();
  * @param[in] place Denotes the execution place (device) on which the module
  * should be registered and loaded.
  *
+ * @param[in] on_deserialized_data Callback run on deserialized code object,
+ * before loading it
+ *
+ * @param[in] cb_state void* passed to on_deserialized_data callback
+ *
  * @retval ::ATMI_STATUS_SUCCESS The function has executed successfully.
  *
  * @retval ::ATMI_STATUS_ERROR The function encountered errors.
@@ -78,9 +83,11 @@ atmi_status_t atmi_finalize();
  * @retval ::ATMI_STATUS_UNKNOWN The function encountered errors.
  *
  */
-  atmi_status_t atmi_module_register_from_memory_to_place(void *module_bytes,
-                                                        size_t module_size,
-                                                        atmi_place_t place);
+atmi_status_t atmi_module_register_from_memory_to_place(
+    void *module_bytes, size_t module_size, atmi_place_t place,
+    atmi_status_t (*on_deserialized_data)(void *data, size_t size,
+                                          void *cb_state),
+    void *cb_state);
 
 /** @} */
 

--- a/openmp/libomptarget/plugins/hsa/impl/rt.h
+++ b/openmp/libomptarget/plugins/hsa/impl/rt.h
@@ -74,7 +74,12 @@ class Runtime final {
   static atmi_status_t Finalize();
 
   // modules
-  static atmi_status_t RegisterModuleFromMemory(void *, size_t, atmi_place_t);
+  static atmi_status_t RegisterModuleFromMemory(
+      void *, size_t, atmi_place_t,
+      atmi_status_t (*on_deserialized_data)(void *data, size_t size,
+                                            void *cb_state),
+      void *cb_state);
+
   // machine info
   static atmi_machine_t *GetMachineInfo();
 

--- a/openmp/libomptarget/plugins/hsa/impl/system.cpp
+++ b/openmp/libomptarget/plugins/hsa/impl/system.cpp
@@ -1049,9 +1049,11 @@ static hsa_status_t populate_InfoTables(hsa_executable_t executable,
   return HSA_STATUS_SUCCESS;
 }
 
-atmi_status_t Runtime::RegisterModuleFromMemory(void *module_bytes,
-                                                size_t module_size,
-                                                atmi_place_t place) {
+atmi_status_t Runtime::RegisterModuleFromMemory(
+    void *module_bytes, size_t module_size, atmi_place_t place,
+    atmi_status_t (*on_deserialized_data)(void *data, size_t size,
+                                          void *cb_state),
+    void *cb_state) {
   hsa_status_t err;
   int gpu = place.device_id;
   assert(gpu >= 0);
@@ -1088,6 +1090,11 @@ atmi_status_t Runtime::RegisterModuleFromMemory(void *module_bytes,
                                         &code_object);
       ErrorCheckAndContinue(Code Object Deserialization, err);
       assert(0 != code_object.handle);
+
+      // Mutating the device image here avoids another allocation & memcpy
+      void * code_object_alloc_data = reinterpret_cast<void*>(code_object.handle);
+      atmi_status_t atmi_err = on_deserialized_data(code_object_alloc_data, module_size, cb_state);
+      ATMIErrorCheck(Error in deserialized_data callback, atmi_err);
 
       /* Load the code object.  */
       err =

--- a/openmp/libomptarget/plugins/hsa/src/rtl.cpp
+++ b/openmp/libomptarget/plugins/hsa/src/rtl.cpp
@@ -846,6 +846,18 @@ atmi_status_t interop_get_symbol_info(char *base, size_t img_size,
     return ATMI_STATUS_ERROR;
   }
 }
+
+template <typename C>
+atmi_status_t module_register_from_memory_to_place(void *module_bytes,
+                                                   size_t module_size,
+                                                   atmi_place_t place, C cb) {
+  auto L = [](void *data, size_t size, void *cb_state) -> atmi_status_t {
+    C *unwrapped = static_cast<C *>(cb_state);
+    return (*unwrapped)(data, size);
+  };
+  return atmi_module_register_from_memory_to_place(
+      module_bytes, module_size, place, L, static_cast<void *>(&cb));
+}
 } // namespace
 
 static __tgt_target_table *__tgt_rtl_load_binary_locked(int32_t device_id,
@@ -875,10 +887,42 @@ __tgt_target_table *__tgt_rtl_load_binary_locked(int32_t device_id,
     return NULL;
   }
 
+  omptarget_device_environmentTy host_device_env;
+  host_device_env.num_devices = DeviceInfo.NumberOfDevices;
+  host_device_env.device_num = device_id;
+  host_device_env.debug_level = 0;
+#ifdef OMPTARGET_DEBUG
+  if (char *envStr = getenv("LIBOMPTARGET_DEVICE_RTL_DEBUG")) {
+    host_device_env.debug_level = std::stoi(envStr);
+  }
+#endif
+
+  auto on_deserialized_data = [&](void *data, size_t size) -> atmi_status_t {
+    const char *device_env_Name = "omptarget_device_environment";
+    symbol_info si;
+    int rc = get_symbol_info_without_loading((char *)image->ImageStart,
+                                             img_size, device_env_Name, &si);
+    if (rc != 0) {
+      DP("Finding global device environment '%s' - symbol missing.\n",
+         device_env_Name);
+      // no need to return FAIL, consider this is a not a device debug build.
+      return ATMI_STATUS_SUCCESS;
+    }
+    if (si.size != sizeof(host_device_env)) {
+      return ATMI_STATUS_ERROR;
+    }
+    DP("Setting global device environment %lu bytes\n", si.size);
+    uint64_t offset = (char *)si.addr - (char *)image->ImageStart;
+    void *pos = (char *)data + offset;
+    memcpy(pos, &host_device_env, sizeof(host_device_env));
+    return ATMI_STATUS_SUCCESS;
+  };
+
   atmi_status_t err;
   {
-    err = atmi_module_register_from_memory_to_place(
-        (void *)image->ImageStart, img_size, get_gpu_place(device_id));
+    err = module_register_from_memory_to_place(
+        (void *)image->ImageStart, img_size, get_gpu_place(device_id),
+        on_deserialized_data);
 
     check("Module registering", err);
     if (err != ATMI_STATUS_SUCCESS) {
@@ -1150,52 +1194,6 @@ __tgt_target_table *__tgt_rtl_load_binary_locked(int32_t device_id,
     entry.addr = (void *)&KernelsList.back();
     DeviceInfo.addOffloadEntry(device_id, entry);
     DP("Entry point %ld maps to %s\n", e - HostBegin, e->name);
-  }
-
-  { // send device environment here
-
-    omptarget_device_environmentTy host_device_env;
-    host_device_env.num_devices = DeviceInfo.NumberOfDevices;
-    host_device_env.device_num = device_id;
-    host_device_env.debug_level = 0;
-#ifdef OMPTARGET_DEBUG
-    if (char *envStr = getenv("LIBOMPTARGET_DEVICE_RTL_DEBUG")) {
-      host_device_env.debug_level = std::stoi(envStr);
-    }
-#endif
-
-    const char *device_env_Name = "omptarget_device_environment";
-    void *device_env_Ptr;
-    uint32_t varsize;
-
-    atmi_mem_place_t place = get_gpu_mem_place(device_id);
-    err = atmi_interop_hsa_get_symbol_info(place, device_env_Name,
-                                           &device_env_Ptr, &varsize);
-
-    if (err == ATMI_STATUS_SUCCESS) {
-      if ((size_t)varsize != sizeof(host_device_env)) {
-        DP("Global device_environment '%s' - size mismatch (%u != %lu)\n",
-           device_env_Name, varsize, sizeof(int32_t));
-        return NULL;
-      }
-
-      err = atmi_memcpy(device_env_Ptr, &host_device_env, (size_t)varsize);
-      if (err != ATMI_STATUS_SUCCESS) {
-        DP("Error when copying data from host to device. Pointers: "
-           "host = " DPxMOD ", device = " DPxMOD ", size = %u\n",
-           DPxPTR(&host_device_env), DPxPTR(device_env_Ptr), varsize);
-        return NULL;
-      }
-
-      DP("Sending global device environment %lu bytes\n", (size_t)varsize);
-    } else {
-      DP("Finding global device environment '%s' - symbol missing.\n",
-         device_env_Name);
-      // no need to return NULL, consider this is a not a device debug build.
-      // return NULL;
-    }
-
-    check("Sending device environment", err);
   }
 
   return DeviceInfo.getOffloadEntriesTable(device_id);


### PR DESCRIPTION
NFC. Removes an atmi_memcpy at image load time. Adds a hook between deserialize and load where the device image can be mutated by the caller, in this case to write the omptarget_device_environmentTy object.

Some line noise from routing through the C interface in atmi_runtime.h.

Previous patches to avoid atmi_memcpy (primarily because it launches a kernel on the gpu, which is not good for startup time) read data from the elf. This one writes to it.