### PR TITLE
Fix nogpulib in hip, lost part of upstream D68300

### DIFF
--- a/clang/lib/Driver/ToolChains/HIP.cpp
+++ b/clang/lib/Driver/ToolChains/HIP.cpp
@@ -271,6 +271,9 @@ void HIPToolChain::addClangTargetOptions(
     CC1Args.append({"-fvisibility", "hidden"});
     CC1Args.push_back("-fapply-global-visibility-to-externs");
   }
+
+  if (DriverArgs.hasArg(options::OPT_nogpulib))
+    return;
   ArgStringList LibraryPaths;
 
   // Find in --hip-device-lib-path and HIP_LIBRARY_PATH.


### PR DESCRIPTION
Part of https://reviews.llvm.org/D68300, still present in amd-stg-open. Looks like a merge error.

Reintroducing this allows one to build the deviceRTL again (by passing nogpulib).

aomp-stg-openmp's HIP.cpp also ignores nogpulib, but I think we get a working build of deviceRTL anyway as the rocm search method is different. Suggest we add this to amd-stg-open anyway as users may expect nogpulib to work, especially when an error message recommends using it.