### PR TITLE
Simplify atmi_memcpy, dropping unused D2D and H2H paths

### DIFF
--- a/openmp/libomptarget/plugins/hsa/impl/data.cpp
+++ b/openmp/libomptarget/plugins/hsa/impl/data.cpp
@@ -127,73 +127,71 @@ atmi_status_t Runtime::Memfree(void *ptr) {
   return ret;
 }
 
-atmi_status_t Runtime::Memcpy(void *dest, const void *src, size_t size) {
-  atmi_status_t ret;
-  hsa_status_t err;
-  ATLData *volatile src_data = g_data_map.find(src);
-  ATLData *volatile dest_data = g_data_map.find(dest);
-  atmi_mem_place_t cpu = ATMI_MEM_PLACE_CPU_MEM(0, 0, 0);
-  hsa_agent_t cpu_agent = get_mem_agent(cpu);
-  hsa_agent_t src_agent;
-  hsa_agent_t dest_agent;
-  void *temp_host_ptr;
-  const void *src_ptr = src;
-  void *dest_ptr = dest;
-  volatile Direction type;
-  if (src_data && !dest_data) {
-    type = Direction::ATMI_D2H;
-    src_agent = get_mem_agent(src_data->place());
-    dest_agent = src_agent;
-    // dest_agent = cpu_agent; // FIXME: can the two agents be the GPU agent
-    // itself?
-    ret = atmi_malloc(&temp_host_ptr, size, cpu);
-    // err = hsa_amd_agents_allow_access(1, &src_agent, NULL, temp_host_ptr);
-    // ErrorCheck(Allow access to ptr, err);
-    src_ptr = src;
-    dest_ptr = temp_host_ptr;
-  } else if (!src_data && dest_data) {
-    type = Direction::ATMI_H2D;
-    dest_agent = get_mem_agent(dest_data->place());
-    // src_agent = cpu_agent; // FIXME: can the two agents be the GPU agent
-    // itself?
-    src_agent = dest_agent;
-    ret = atmi_malloc(&temp_host_ptr, size, cpu);
-    memcpy(temp_host_ptr, src, size);
-    // FIXME: ideally lock would be the better approach, but we need to try to
-    // understand why the h2d copy segfaults if we dont have the below lines
-    // err = hsa_amd_agents_allow_access(1, &dest_agent, NULL, temp_host_ptr);
-    // ErrorCheck(Allow access to ptr, err);
-    src_ptr = (const void *)temp_host_ptr;
-    dest_ptr = dest;
-  } else if (!src_data && !dest_data) {
-    type = Direction::ATMI_H2H;
-    src_agent = cpu_agent;
-    dest_agent = cpu_agent;
-    src_ptr = src;
-    dest_ptr = dest;
-  } else {
-    type = Direction::ATMI_D2D;
-    src_agent = get_mem_agent(src_data->place());
-    dest_agent = get_mem_agent(dest_data->place());
-    src_ptr = src;
-    dest_ptr = dest;
-  }
-  DEBUG_PRINT("Memcpy source agent: %lu\n", src_agent.handle);
-  DEBUG_PRINT("Memcpy dest agent: %lu\n", dest_agent.handle);
+static hsa_status_t invoke_hsa_copy(void *dest, const void *src, size_t size,
+                                    hsa_agent_t agent) {
+  // TODO: Use thread safe signal
   hsa_signal_store_release(IdentityCopySignal, 1);
-  err = hsa_amd_memory_async_copy(dest_ptr, dest_agent, src_ptr, src_agent,
-                                  size, 0, NULL, IdentityCopySignal);
+
+  hsa_status_t err = hsa_amd_memory_async_copy(dest, agent, src, agent, size, 0,
+                                               NULL, IdentityCopySignal);
   ErrorCheck(Copy async between memory pools, err);
+
+  // TODO: async reports errors in the signal, use NE 1
   hsa_signal_wait_acquire(IdentityCopySignal, HSA_SIGNAL_CONDITION_EQ, 0,
                           UINT64_MAX, ATMI_WAIT_STATE);
 
-  // cleanup for D2H and H2D
-  if (type == Direction::ATMI_D2H) {
+  return err;
+}
+
+atmi_status_t Runtime::Memcpy(void *dest, const void *src, size_t size) {
+  atmi_status_t ret;
+  hsa_status_t err;
+  ATLData * src_data = g_data_map.find(src);
+  ATLData * dest_data = g_data_map.find(dest);
+  atmi_mem_place_t cpu = ATMI_MEM_PLACE_CPU_MEM(0, 0, 0);
+  void *temp_host_ptr;
+
+  if (src_data && !dest_data) {
+    // Copy from device to scratch to host
+    hsa_agent_t agent = get_mem_agent(src_data->place());
+    DEBUG_PRINT("Memcpy D2H device agent: %lu\n", agent.handle);
+    ret = atmi_malloc(&temp_host_ptr, size, cpu);
+    if (ret != ATMI_STATUS_SUCCESS) {
+      return ret;
+    }
+
+    err = invoke_hsa_copy(temp_host_ptr, src, size, agent);
+    if (err != HSA_STATUS_SUCCESS) {
+      return ATMI_STATUS_ERROR;
+    }
+
     memcpy(dest, temp_host_ptr, size);
-    ret = atmi_free(temp_host_ptr);
-  } else if (type == Direction::ATMI_H2D) {
-    ret = atmi_free(temp_host_ptr);
+
+  } else if (!src_data && dest_data) {
+    // Copy from host to scratch to device
+    hsa_agent_t agent = get_mem_agent(dest_data->place());
+    DEBUG_PRINT("Memcpy H2D device agent: %lu\n", agent.handle);
+    ret = atmi_malloc(&temp_host_ptr, size, cpu);
+    if (ret != ATMI_STATUS_SUCCESS) {
+      return ret;
+    }
+
+    memcpy(temp_host_ptr, src, size);
+
+    DEBUG_PRINT("Memcpy device agent: %lu\n", agent.handle);
+    err = invoke_hsa_copy(dest, temp_host_ptr, size, agent);
+
+  } else if (!src_data && !dest_data) {
+    DEBUG_PRINT("atmi_memcpy invoked without metadata\n");
+    // would be host to host, just call memcpy, or missing metadata
+    return ATMI_STATUS_ERROR;
+  } else {
+    DEBUG_PRINT("atmi_memcpy unimplemented device to device copy\n");
+    return ATMI_STATUS_ERROR;
   }
+
+  ret = atmi_free(temp_host_ptr);
+  
   if (err != HSA_STATUS_SUCCESS || ret != ATMI_STATUS_SUCCESS)
     ret = ATMI_STATUS_ERROR;
   return ret;


### PR DESCRIPTION
No functional change to D2H and H2D paths. Left TODOs on the race condition and missing error handling that are apparent after the refactor, those should be fixed in atmi as well as this fork.

atmi_memcpy involves recording metadata on pointers at allocation and then guessing that pointers which do not have said metadata are on the host cpu. This means a pointer to gpu memory that has not been registered with atmi will be read as if it were host memory.

Dropping the unused paths makes it clear that src_agent and dst_agent both refer to the same gpu. Each caller of this function knows which gpu the pointer is associated with, so a following patch can drop the metadata. That reduces atmi_malloc and atmi_free to simple wrappers around hsa memory pool functions.

This patch makes no change to the semantics of plugin/hsa (other than updating debug messages). invoke_hsa_copy is factored out to drop the Direction enum and make it clearer that both live paths involve a scratch buffer, device copy and host copy.