### PR TITLE
Refactor signal pool. 

### DIFF
--- a/openmp/libomptarget/plugins/hsa/impl/internal.h
+++ b/openmp/libomptarget/plugins/hsa/impl/internal.h
@@ -122,33 +122,60 @@ class Kernel;
 class KernelImpl;
 }  // namespace core
 
-
-extern std::queue<core::TaskImpl *> ReadyTaskQueue;
-
 struct SignalPoolT {
-  SignalPoolT() = default;
+  SignalPoolT() {
+    // If no signals are created, and none can be created later,
+    // will ultimately fail at pop()
+
+    unsigned N = 1024; // default max pool size from atmi
+    for (unsigned i = 0; i < N; i++) {
+      hsa_signal_t new_signal;
+      hsa_status_t err = hsa_signal_create(0, 0, NULL, &new_signal);
+      if (err != HSA_STATUS_SUCCESS) {
+        break;
+      }
+      state.push(new_signal);
+    }
+    DEBUG_PRINT("Signal Pool Initial Size: %lu\n", state.size());
+  }
   SignalPoolT(const SignalPoolT &) = delete;
   SignalPoolT(SignalPoolT &&) = delete;
-
+  ~SignalPoolT() {
+    size_t N = state.size();
+    for (size_t i = 0; i < N; i++) {
+      hsa_signal_t signal = state.front();
+      state.pop();
+      hsa_status_t rc = hsa_signal_destroy(signal);
+      if (rc != HSA_STATUS_SUCCESS) {
+        DEBUG_PRINT("Signal pool destruction failed\n");
+      }
+    }
+  }
   size_t size() {
     lock l(&mutex);
     return state.size();
-  }
-  bool empty() {
-    lock l(&mutex);
-    return state.empty();
   }
   void push(hsa_signal_t s) {
     lock l(&mutex);
     state.push(s);
   }
-  hsa_signal_t front() {
+  hsa_signal_t pop(void) {
     lock l(&mutex);
-    return state.front();
-  }
-  void pop(void) {
-    lock l(&mutex);
-    state.pop();
+    if (!state.empty()) {
+      hsa_signal_t res = state.front();
+      state.pop();
+      return res;
+    }
+
+    // Pool empty, attempt to create another signal
+    hsa_signal_t new_signal;
+    hsa_status_t err = hsa_signal_create(0, 0, NULL, &new_signal);
+    if (err == HSA_STATUS_SUCCESS) {
+      return new_signal;
+    }
+
+    // Fail
+    return {0};
   }
 
 private:
@@ -161,7 +188,6 @@ private:
   };
 };
 
-extern SignalPoolT FreeSignalPool;
 extern std::vector<hsa_amd_memory_pool_t> atl_gpu_kernarg_pools;
 
 namespace core {

--- a/openmp/libomptarget/plugins/hsa/impl/rt.h
+++ b/openmp/libomptarget/plugins/hsa/impl/rt.h
@@ -13,7 +13,6 @@
 
 namespace core {
 
-#define DEFAULT_MAX_SIGNALS 1024
 #define DEFAULT_MAX_QUEUE_SIZE 4096
 #define DEFAULT_MAX_KERNEL_TYPES 32
 #define DEFAULT_NUM_GPU_QUEUES -1  // computed in code
@@ -22,8 +21,7 @@ namespace core {
 class Environment {
  public:
   Environment()
-      : max_signals_(DEFAULT_MAX_SIGNALS),
-        max_queue_size_(DEFAULT_MAX_QUEUE_SIZE),
+      : max_queue_size_(DEFAULT_MAX_QUEUE_SIZE),
         max_kernel_types_(DEFAULT_MAX_KERNEL_TYPES),
         num_gpu_queues_(DEFAULT_NUM_GPU_QUEUES),
         num_cpu_queues_(DEFAULT_NUM_CPU_QUEUES),
@@ -35,7 +33,6 @@ class Environment {
 
   void GetEnvAll();
 
-  int getMaxSignals() const { return max_signals_; }
   int getMaxQueueSize() const { return max_queue_size_; }
   int getMaxKernelTypes() const { return max_kernel_types_; }
   int getNumGPUQueues() const { return num_gpu_queues_; }
@@ -54,7 +51,6 @@ class Environment {
     return ret;
   }
 
-  int max_signals_;
   int max_queue_size_;
   int max_kernel_types_;
   int num_gpu_queues_;
@@ -84,7 +80,6 @@ class Runtime final {
   static atmi_status_t Malloc(void **, size_t, atmi_mem_place_t);
 
   // environment variables
-  int getMaxSignals() const { return env_.getMaxSignals(); }
   int getMaxQueueSize() const { return env_.getMaxQueueSize(); }
   int getMaxKernelTypes() const { return env_.getMaxKernelTypes(); }
   int getNumGPUQueues() const { return env_.getNumGPUQueues(); }

--- a/openmp/libomptarget/plugins/hsa/impl/system.cpp
+++ b/openmp/libomptarget/plugins/hsa/impl/system.cpp
@@ -151,9 +151,6 @@ std::map<std::string, std::string> KernelNameMap;
 std::vector<std::map<std::string, atl_kernel_info_t> > KernelInfoTable;
 std::vector<std::map<std::string, atl_symbol_info_t> > SymbolInfoTable;
 
-SignalPoolT FreeSignalPool;
-pthread_mutex_t SignalPoolT::mutex = PTHREAD_MUTEX_INITIALIZER;
-
 bool g_atmi_initialized = false;
 bool g_atmi_hostcall_required = false;
 
@@ -561,16 +558,8 @@ void init_tasks() {
     ATLGPUProcessor &proc = get_processor<ATLGPUProcessor>(place);
     gpu_agents.push_back(proc.agent());
   }
-  int max_signals = core::Runtime::getInstance().getMaxSignals();
-  for (task_num = 0; task_num < max_signals; task_num++) {
-    hsa_signal_t new_signal;
-    err = hsa_signal_create(0, 0, NULL, &new_signal);
-    ErrorCheck(Creating a HSA signal, err);
-    FreeSignalPool.push(new_signal);
-  }
   err = hsa_signal_create(0, 0, NULL, &IdentityCopySignal);
   ErrorCheck(Creating a HSA signal, err);
-  DEBUG_PRINT("Signal Pool Size: %lu\n", FreeSignalPool.size());
   atlc.g_tasks_initialized = true;
 }
 

--- a/openmp/libomptarget/plugins/hsa/impl/utils.cpp
+++ b/openmp/libomptarget/plugins/hsa/impl/utils.cpp
@@ -96,17 +96,13 @@ namespace core {
 void Environment::GetEnvAll() {
   std::string var = GetEnv("ATMI_HELP");
   if (!var.empty()) {
-    std::cout << "ATMI_MAX_HSA_SIGNALS : positive integer" << std::endl
-              << "ATMI_MAX_HSA_QUEUE_SIZE : positive integer" << std::endl
+    std::cout << "ATMI_MAX_HSA_QUEUE_SIZE : positive integer" << std::endl
               << "ATMI_MAX_KERNEL_TYPES : positive integer" << std::endl
               << "ATMI_DEVICE_GPU_WORKERS : positive integer" << std::endl
               << "ATMI_DEVICE_CPU_WORKERS : positive integer" << std::endl
               << "ATMI_DEBUG : 1 for printing out trace/debug info" << std::endl;
     exit(0);
   }
-
-  var = GetEnv("ATMI_MAX_HSA_SIGNALS");
-  if (!var.empty()) max_signals_ = std::stoi(var);
 
   var = GetEnv("ATMI_MAX_HSA_QUEUE_SIZE");
   if (!var.empty()) max_queue_size_ = std::stoi(var);

--- a/openmp/libomptarget/plugins/hsa/src/rtl.cpp
+++ b/openmp/libomptarget/plugins/hsa/src/rtl.cpp
@@ -328,7 +328,9 @@ public:
   // OpenMP Requires Flags
   int64_t RequiresFlags;
 
-  // static int EnvNumThreads;
+  // Resource pools
+  SignalPoolT FreeSignalPool;
+  
   static const int HardTeamLimit = 1 << 20; // 1 Meg
   static const int DefaultNumTeams = 128;
   static const int Max_Teams =
@@ -508,6 +510,9 @@ public:
     atmi_finalize();
   }
 };
+
+
+pthread_mutex_t SignalPoolT::mutex = PTHREAD_MUTEX_INITIALIZER;
 
 #include "../../../src/device_env_struct.h"
 
@@ -1458,8 +1463,6 @@ int32_t __tgt_rtl_run_target_team_region(int32_t device_id, void *tgt_entry_ptr,
   // update thread limit content in gpu memory if un-initialized or specified
   // from host
 
-  static pthread_mutex_t run_target_team_region_mutex = PTHREAD_MUTEX_INITIALIZER;
-
   DP("Run target team region thread_limit %d\n", thread_limit);
 
   // All args are references.
@@ -1593,17 +1596,13 @@ int32_t __tgt_rtl_run_target_team_region(int32_t device_id, void *tgt_entry_ptr,
     }
 
     {
-      pthread_mutex_lock(&run_target_team_region_mutex);
-      if (FreeSignalPool.empty()) {
-        // could add to the pool, but atmi doesn't do so
+      hsa_signal_t s = DeviceInfo.FreeSignalPool.pop();
+      if (s.handle == 0) {
         printf("Failed to get signal instance\n");
-        pthread_mutex_unlock(&run_target_team_region_mutex);
         exit(1);
       }
-      packet->completion_signal = FreeSignalPool.front();
+      packet->completion_signal = s;
       hsa_signal_store_relaxed(packet->completion_signal, 1);
-      FreeSignalPool.pop();
-      pthread_mutex_unlock(&run_target_team_region_mutex);
     }
 
     core::packet_store_release(
@@ -1621,7 +1620,7 @@ int32_t __tgt_rtl_run_target_team_region(int32_t device_id, void *tgt_entry_ptr,
 
     assert(ArgPool);
     ArgPool->deallocate(packet->kernarg_address);
-    FreeSignalPool.push(packet->completion_signal);
+    DeviceInfo.FreeSignalPool.push(packet->completion_signal);
   }
 
   DP("Kernel completed\n");


### PR DESCRIPTION
Fewer locks, allocates more signals if > 1024 are requested

Moves the signal pool into rtl so lifespan is bounded with plugin instance instead of independent.

Add signal cleanup to destructor. Didn't notice the lack of destroy calls when looking through atmi. Will be quite verbose if signal cleanup fails, which should only occur on programmer error.