### PR TITLE
Jc lock signal

### DIFF
--- a/openmp/libomptarget/plugins/hsa/impl/rt.h
+++ b/openmp/libomptarget/plugins/hsa/impl/rt.h
@@ -13,7 +13,6 @@
 
 namespace core {
 
-#define DEFAULT_MAX_SIGNALS 1024
 #define DEFAULT_MAX_QUEUE_SIZE 4096
 #define DEFAULT_MAX_KERNEL_TYPES 32
 #define DEFAULT_NUM_GPU_QUEUES -1  // computed in code
@@ -22,8 +21,7 @@ namespace core {
 class Environment {
  public:
   Environment()
-      : max_signals_(DEFAULT_MAX_SIGNALS),
-        max_queue_size_(DEFAULT_MAX_QUEUE_SIZE),
+      : max_queue_size_(DEFAULT_MAX_QUEUE_SIZE),
         max_kernel_types_(DEFAULT_MAX_KERNEL_TYPES),
         num_gpu_queues_(DEFAULT_NUM_GPU_QUEUES),
         num_cpu_queues_(DEFAULT_NUM_CPU_QUEUES),
@@ -35,7 +33,6 @@ class Environment {
 
   void GetEnvAll();
 
-  int getMaxSignals() const { return max_signals_; }
   int getMaxQueueSize() const { return max_queue_size_; }
   int getMaxKernelTypes() const { return max_kernel_types_; }
   int getNumGPUQueues() const { return num_gpu_queues_; }
@@ -54,7 +51,6 @@ class Environment {
     return ret;
   }
 
-  int max_signals_;
   int max_queue_size_;
   int max_kernel_types_;
   int num_gpu_queues_;
@@ -83,7 +79,6 @@ class Runtime final {
   static atmi_status_t Malloc(void **, size_t, atmi_mem_place_t);
 
   // environment variables
-  int getMaxSignals() const { return env_.getMaxSignals(); }
   int getMaxQueueSize() const { return env_.getMaxQueueSize(); }
   int getMaxKernelTypes() const { return env_.getMaxKernelTypes(); }
   int getNumGPUQueues() const { return env_.getNumGPUQueues(); }

--- a/openmp/libomptarget/plugins/hsa/impl/system.cpp
+++ b/openmp/libomptarget/plugins/hsa/impl/system.cpp
@@ -151,9 +151,6 @@ std::map<std::string, std::string> KernelNameMap;
 std::vector<std::map<std::string, atl_kernel_info_t> > KernelInfoTable;
 std::vector<std::map<std::string, atl_symbol_info_t> > SymbolInfoTable;
 
-SignalPoolT FreeSignalPool;
-pthread_mutex_t SignalPoolT::mutex = PTHREAD_MUTEX_INITIALIZER;
-
 bool g_atmi_initialized = false;
 bool g_atmi_hostcall_required = false;
 
@@ -561,16 +558,8 @@ void init_tasks() {
     ATLGPUProcessor &proc = get_processor<ATLGPUProcessor>(place);
     gpu_agents.push_back(proc.agent());
   }
-  int max_signals = core::Runtime::getInstance().getMaxSignals();
-  for (task_num = 0; task_num < max_signals; task_num++) {
-    hsa_signal_t new_signal;
-    err = hsa_signal_create(0, 0, NULL, &new_signal);
-    ErrorCheck(Creating a HSA signal, err);
-    FreeSignalPool.push(new_signal);
-  }
   err = hsa_signal_create(0, 0, NULL, &IdentityCopySignal);
   ErrorCheck(Creating a HSA signal, err);
-  DEBUG_PRINT("Signal Pool Size: %lu\n", FreeSignalPool.size());
   atlc.g_tasks_initialized = true;
 }
 

--- a/openmp/libomptarget/plugins/hsa/impl/system.cpp
+++ b/openmp/libomptarget/plugins/hsa/impl/system.cpp
@@ -151,7 +151,8 @@ std::map<std::string, std::string> KernelNameMap;
 std::vector<std::map<std::string, atl_kernel_info_t> > KernelInfoTable;
 std::vector<std::map<std::string, atl_symbol_info_t> > SymbolInfoTable;
 
-std::queue<hsa_signal_t> FreeSignalPool;
+SignalPoolT FreeSignalPool;
+pthread_mutex_t SignalPoolT::mutex = PTHREAD_MUTEX_INITIALIZER;
 
 bool g_atmi_initialized = false;
 bool g_atmi_hostcall_required = false;

--- a/openmp/libomptarget/plugins/hsa/impl/utils.cpp
+++ b/openmp/libomptarget/plugins/hsa/impl/utils.cpp
@@ -96,17 +96,13 @@ namespace core {
 void Environment::GetEnvAll() {
   std::string var = GetEnv("ATMI_HELP");
   if (!var.empty()) {
-    std::cout << "ATMI_MAX_HSA_SIGNALS : positive integer" << std::endl
-              << "ATMI_MAX_HSA_QUEUE_SIZE : positive integer" << std::endl
+    std::cout << "ATMI_MAX_HSA_QUEUE_SIZE : positive integer" << std::endl
               << "ATMI_MAX_KERNEL_TYPES : positive integer" << std::endl
               << "ATMI_DEVICE_GPU_WORKERS : positive integer" << std::endl
               << "ATMI_DEVICE_CPU_WORKERS : positive integer" << std::endl
               << "ATMI_DEBUG : 1 for printing out trace/debug info" << std::endl;
     exit(0);
   }
-
-  var = GetEnv("ATMI_MAX_HSA_SIGNALS");
-  if (!var.empty()) max_signals_ = std::stoi(var);
 
   var = GetEnv("ATMI_MAX_HSA_QUEUE_SIZE");
   if (!var.empty()) max_queue_size_ = std::stoi(var);


### PR DESCRIPTION
Import two patches from aomp12. Lock accesses to signals pool, allow applications to use more than 1024 at a time, destroy the allocated signals at end of execution.

Cleans up the locking around KernelArgPool in passing as it's the same pattern as locking the signal pool.