### PR TITLE
Import async patches, setting up device environment without memcpy

### DIFF
--- a/openmp/libomptarget/deviceRTLs/common/src/omp_data.cu
+++ b/openmp/libomptarget/deviceRTLs/common/src/omp_data.cu
@@ -17,6 +17,11 @@
 // global device environment
 ////////////////////////////////////////////////////////////////////////////////
 
+#ifdef __AMDGCN__
+// Keeping the variable out of bss allows it to be initialized before
+// loading the device image
+__attribute__((section(".data")))
+#endif
 DEVICE omptarget_device_environmentTy omptarget_device_environment;
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/openmp/libomptarget/plugins/hsa/impl/atmi.cpp
+++ b/openmp/libomptarget/plugins/hsa/impl/atmi.cpp
@@ -25,13 +25,14 @@ atmi_machine_t *atmi_machine_get_info() {
 /*
  * Modules
  */
-atmi_status_t atmi_module_register_from_memory_to_place(void *module_bytes,
-                                                        size_t module_size,
-                                                        atmi_place_t place) {
-  return core::Runtime::RegisterModuleFromMemory(
-      module_bytes, module_size, place);
+atmi_status_t atmi_module_register_from_memory_to_place(
+    void *module_bytes, size_t module_size, atmi_place_t place,
+    atmi_status_t (*on_deserialized_data)(void *data, size_t size,
+                                          void *cb_state),
+    void *cb_state) {
+  return core::Runtime::getInstance().RegisterModuleFromMemory(
+      module_bytes, module_size, place, on_deserialized_data, cb_state);
 }
-
 
 /*
  * Data

--- a/openmp/libomptarget/plugins/hsa/impl/atmi_runtime.h
+++ b/openmp/libomptarget/plugins/hsa/impl/atmi_runtime.h
@@ -72,6 +72,11 @@ atmi_status_t atmi_finalize();
  * @param[in] place Denotes the execution place (device) on which the module
  * should be registered and loaded.
  *
+ * @param[in] on_deserialized_data Callback run on deserialized code object,
+ * before loading it
+ *
+ * @param[in] cb_state void* passed to on_deserialized_data callback
+ *
  * @retval ::ATMI_STATUS_SUCCESS The function has executed successfully.
  *
  * @retval ::ATMI_STATUS_ERROR The function encountered errors.
@@ -79,9 +84,11 @@ atmi_status_t atmi_finalize();
  * @retval ::ATMI_STATUS_UNKNOWN The function encountered errors.
  *
  */
-  atmi_status_t atmi_module_register_from_memory_to_place(void *module_bytes,
-                                                        size_t module_size,
-                                                        atmi_place_t place);
+atmi_status_t atmi_module_register_from_memory_to_place(
+    void *module_bytes, size_t module_size, atmi_place_t place,
+    atmi_status_t (*on_deserialized_data)(void *data, size_t size,
+                                          void *cb_state),
+    void *cb_state);
 
 /** @} */
 

--- a/openmp/libomptarget/plugins/hsa/impl/rt.h
+++ b/openmp/libomptarget/plugins/hsa/impl/rt.h
@@ -58,7 +58,12 @@ class Runtime final {
   // machine info
   static atmi_machine_t *GetMachineInfo();
   // modules
-  static atmi_status_t RegisterModuleFromMemory(void *, size_t, atmi_place_t);
+  static atmi_status_t RegisterModuleFromMemory(
+      void *, size_t, atmi_place_t,
+      atmi_status_t (*on_deserialized_data)(void *data, size_t size,
+                                            void *cb_state),
+      void *cb_state);
+
 
   // data
   static atmi_status_t Memcpy(hsa_signal_t, void *, const void *, size_t);

--- a/openmp/libomptarget/plugins/hsa/impl/system.cpp
+++ b/openmp/libomptarget/plugins/hsa/impl/system.cpp
@@ -1008,9 +1008,11 @@ static hsa_status_t populate_InfoTables(hsa_executable_t executable,
   return HSA_STATUS_SUCCESS;
 }
 
-atmi_status_t Runtime::RegisterModuleFromMemory(void *module_bytes,
-                                                size_t module_size,
-                                                atmi_place_t place) {
+atmi_status_t Runtime::RegisterModuleFromMemory(
+    void *module_bytes, size_t module_size, atmi_place_t place,
+    atmi_status_t (*on_deserialized_data)(void *data, size_t size,
+                                          void *cb_state),
+    void *cb_state) {
   hsa_status_t err;
   int gpu = place.device_id;
   assert(gpu >= 0);
@@ -1047,6 +1049,11 @@ atmi_status_t Runtime::RegisterModuleFromMemory(void *module_bytes,
                                         &code_object);
       ErrorCheckAndContinue(Code Object Deserialization, err);
       assert(0 != code_object.handle);
+
+      // Mutating the device image here avoids another allocation & memcpy
+      void * code_object_alloc_data = reinterpret_cast<void*>(code_object.handle);
+      atmi_status_t atmi_err = on_deserialized_data(code_object_alloc_data, module_size, cb_state);
+      ATMIErrorCheck(Error in deserialized_data callback, atmi_err);
 
       /* Load the code object.  */
       err =


### PR DESCRIPTION
Comments plus eliding a memcpy. Leaves amd-stg-openmp and aomp12 plugins functionally equivalent.