### PR TITLE
Avoid the misleading ompd_tool_break not defined

### DIFF
--- a/openmp/libompd/gdb-plugin/ompd/ompd_address_space.py
+++ b/openmp/libompd/gdb-plugin/ompd/ompd_address_space.py
@@ -25,10 +25,13 @@ class ompd_address_space(object):
 		self.threads = {}
 		self.states = None
 		self.icv_map = None
+                self.ompd_tool_test_bp = None
 		self.scope_map = {1:'global', 2:'address_space', 3:'thread', 4:'parallel', 5:'implicit_task', 6:'task'}
 		gdb.events.stop.connect(self.handle_stop_event)
 		self.new_thread_breakpoint = gdb.Breakpoint("ompd_bp_thread_begin", internal=True)
-		self.ompd_tool_test_bp = gdb.Breakpoint("ompd_tool_break", internal=True)
+                tool_break_symbol = gdb.lookup_global_symbol("ompd_tool_break")
+                if tool_break_symbol is not None:
+		        self.ompd_tool_test_bp = gdb.Breakpoint("ompd_tool_break", internal=True)
 	
 	def handle_stop_event(self, event):
 		"""Sets a breakpoint at different events, e.g. when a new OpenMP 
@@ -40,7 +43,7 @@ class ompd_address_space(object):
 				self.add_thread()
 				gdb.execute('continue')
 				return
-			elif(self.ompd_tool_test_bp in event.breakpoints):
+			elif(self.ompd_tool_test_bp is not None and self.ompd_tool_test_bp in event.breakpoints):
 				self.compare_ompt_data()
 		elif (isinstance(event, gdb.SignalEvent)):
 			# TODO: what do we need to do on SIGNALS?


### PR DESCRIPTION
Setting a breakpoint in ompd_tool_break only if the ompd_tool_break symbol can be found. 