### PR TITLE
Use non-deprecated hsa calls

### DIFF
--- a/openmp/libomptarget/plugins/hsa/impl/data.cpp
+++ b/openmp/libomptarget/plugins/hsa/impl/data.cpp
@@ -131,7 +131,7 @@ static hsa_status_t invoke_hsa_copy(hsa_signal_t sig, void *dest,
                                     hsa_agent_t agent) {
   const hsa_signal_value_t init = 1;
   const hsa_signal_value_t success = 0;
-  hsa_signal_store_release(sig, init);
+  hsa_signal_store_screlease(sig, init);
 
   hsa_status_t err = hsa_amd_memory_async_copy(dest, agent, src, agent, size, 0,
                                                NULL, sig);
@@ -142,8 +142,8 @@ static hsa_status_t invoke_hsa_copy(hsa_signal_t sig, void *dest,
   // async_copy reports success by decrementing and failure by setting to < 0
   hsa_signal_value_t got = init;
   while (got == init) {
-    got = hsa_signal_wait_acquire(sig, HSA_SIGNAL_CONDITION_NE, init,
-                                  UINT64_MAX, ATMI_WAIT_STATE);
+    got = hsa_signal_wait_scacquire(sig, HSA_SIGNAL_CONDITION_NE, init,
+                                    UINT64_MAX, ATMI_WAIT_STATE);
   }
 
   if (got != success) {

--- a/openmp/libomptarget/plugins/hsa/src/rtl.cpp
+++ b/openmp/libomptarget/plugins/hsa/src/rtl.cpp
@@ -1560,7 +1560,7 @@ static uint64_t acquire_available_packet_id(hsa_queue_t *queue) {
   bool full = true;
   while (full) {
     full =
-        packet_id >= (queue->size + hsa_queue_load_read_index_acquire(queue));
+        packet_id >= (queue->size + hsa_queue_load_read_index_scacquire(queue));
   }
   return packet_id;
 }
@@ -1749,9 +1749,9 @@ int32_t __tgt_rtl_run_target_team_region_locked(int32_t device_id, void *tgt_ent
 
     hsa_signal_store_relaxed(queue->doorbell_signal, packet_id);
 
-    while (hsa_signal_wait_acquire(packet->completion_signal,
-                                   HSA_SIGNAL_CONDITION_EQ, 0, UINT64_MAX,
-                                   HSA_WAIT_STATE_BLOCKED) != 0)
+    while (hsa_signal_wait_scacquire(packet->completion_signal,
+                                     HSA_SIGNAL_CONDITION_EQ, 0, UINT64_MAX,
+                                     HSA_WAIT_STATE_BLOCKED) != 0)
       ;
 
     assert(ArgPool);


### PR DESCRIPTION
The deprecated functions are implemented as aliases in the hsa shared library, but are missing entirely from the hsa static library. Easier to fix the plugin source to use the symbols that are available in both than to add the deprecated functions to hsa.

Combined with amd-llvm-project/pull/143, a step towards statically linking hsa into the plugin.