### PR TITLE
Update plugin to use cmake find_package in the same style as rocm-3.7

### DIFF
--- a/openmp/libomptarget/plugins/hsa/CMakeLists.txt
+++ b/openmp/libomptarget/plugins/hsa/CMakeLists.txt
@@ -14,6 +14,13 @@
 ################################################################################
 # Add check for required compiler
 
+# as of rocm-3.7, hsa is installed with cmake packages and kmt is found via hsa
+find_package(hsa-runtime64 QUIET 1.2.0 HINTS ${CMAKE_INSTALL_PREFIX} PATHS /opt/rocm)
+if (NOT ${hsa-runtime64_FOUND})
+  libomptarget_say("Not building HSA plugin: hsa-runtime64 not found")
+  return()
+endif()
+
 find_package(LLVM QUIET CONFIG PATHS ${LLVM_INSTALL_PREFIX} ${CMAKE_INSTALL_PREFIX} NO_DEFAULT_PATH)
 
 if (LLVM_DIR)
@@ -38,32 +45,12 @@ if(NOT LIBOMPTARGET_DEP_LIBELF_FOUND)
   return()
 endif()
 
-# rocr cmake uses DHSAKMT_INC_PATH, DHSAKMT_LIB_PATH to find roct
-# following that, look for DHSA_INC_PATH, DHSA_LIB_PATH, which allows
-# builds to use source and library files from various locations
-
-if(ROCM_DIR)
-  set(HSA_INC_PATH ${ROCM_DIR}/hsa/include ${ROCM_DIR}/hsa/include/hsa)
-  set(HSA_LIB_PATH ${ROCM_DIR}/hsa/lib)
-  set(HSAKMT_INC_PATH "")
-  set(HSAKMT_LIB_PATH ${ROCM_DIR}/lib)
-elseif(NOT (HSA_INC_PATH AND HSA_LIB_PATH AND HSAKMT_INC_PATH AND HSAKMT_LIB_PATH))
-  libomptarget_say("Not building HSA plugin: ROCM library paths unspecified")
-  return()
-endif()
-
-mark_as_advanced(HSA_INC_PATH HSA_LIB_PATH HSAKMT_INC_PATH HSAKMT_LIB_PATH)
 
 if(NOT CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(ppc64le)|(aarch64)$" AND CMAKE_SYSTEM_NAME MATCHES "Linux")
   libomptarget_say("Not building HSA plugin: only support HSA in Linux x86_64, ppc64le , or aarch64 hosts.")
   return()
 endif()
 libomptarget_say("Building HSA offloading plugin")
-
-libomptarget_say("HSA plugin: HSA_INC_PATH: ${HSA_INC_PATH}")
-libomptarget_say("HSA plugin: HSA_LIB_PATH: ${HSA_LIB_PATH}")
-libomptarget_say("HSA plugin: HSAKMT_INC_PATH: ${HSAKMT_INC_PATH}")
-libomptarget_say("HSA plugin: HSAKMT_LIB_PATH: ${HSAKMT_LIB_PATH}")
 
 ################################################################################
 # Define the suffix for the runtime messaging dumps.
@@ -73,12 +60,10 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "(ppc64le)|(aarch64)$")
 endif()
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)
-  add_definitions(-DHSA_ERROR_REPORT)
   add_definitions(-DDEBUG)
 endif()
 
 include_directories(
-  ${HSA_INC_PATH}
   ${CLANG_INCLUDE_DIRS}
   ${LLVM_INCLUDE_DIRS}
   ${CMAKE_CURRENT_SOURCE_DIR}/impl
@@ -101,16 +86,14 @@ add_definitions(${OPENMP_SOURCE_DEBUG_MAP})
 # When we build for debug, OPENMP_LIBDIR_SUFFIX get set to -debug
 install(TARGETS omptarget.rtl.hsa LIBRARY DESTINATION "lib${OPENMP_LIBDIR_SUFFIX}")
 
-# We need the AOMP specific build of ATMI that has HSA_INTEROP turned on. 
-# Also, the AOMP specific build of ATMI has seperate release and debug builds. 
-
-add_dependencies(omptarget.rtl.hsa hsa-runtime64 hsakmt)
 target_link_libraries(
   omptarget.rtl.hsa
+  PUBLIC
   hostrpc_services
-  -lpthread -ldl -Wl,-rpath,${LLVM_LIBDIR}${OPENMP_LIBDIR_SUFFIX}
-  -L${HSA_LIB_PATH} -L${HSAKMT_LIB_PATH} -lhsa-runtime64 -lhsakmt -Wl,-rpath,${HSA_LIB_PATH},-rpath,${HSAKMT_LIB_PATH}
-  -lelf
+  PRIVATE
+  hsa-runtime64::hsa-runtime64
+  pthread dl elf
+  -Wl,-rpath,${LLVM_LIBDIR}${OPENMP_LIBDIR_SUFFIX}
   "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/../exports"
   "-Wl,-z,defs"
   )


### PR DESCRIPTION
The syntax is essentially copied from rocr's 3.7 update, using the same logic rocr uses to find roct.

hsa is used from ${CMAKE_INSTALL_PREFIX} if available, falling back to /opt/rocm if not. Can be overridden by the user in the usual cmake fashion. Will work as part of the rocm install.

Leaves the rpath setting unchanged, so I believe this will still work as part of a packaged aomp release.

No longer looks for hsakmt as it is found as part of rocr.