### PR TITLE
find_package for Python3 does not update PYTHON_EXECUTABLE.

### DIFF
--- a/openmp/libompd/gdb-plugin/CMakeLists.txt
+++ b/openmp/libompd/gdb-plugin/CMakeLists.txt
@@ -5,7 +5,7 @@ set (CMAKE_MODULE_PATH
 
 find_package (Python3 COMPONENTS Interpreter Development)
 
-execute_process(COMMAND "${PYTHON_EXECUTABLE}"
+execute_process(COMMAND "${Python3_EXECUTABLE}"
 	"-mpip"
 	"--version"
 	OUTPUT_VARIABLE PIP_VERSION_INFO


### PR DESCRIPTION
Instead it modifies Python3_EXECUTABLE. This is required as ompd support recently moved to python3.