### PR TITLE
[OpenMP][AMDGPU] Use DS_Max_Warp_Number instead of WARPSIZE

### DIFF
--- a/openmp/libomptarget/deviceRTLs/common/omptarget.h
+++ b/openmp/libomptarget/deviceRTLs/common/omptarget.h
@@ -273,7 +273,7 @@ private:
       workDescrForActiveParallel; // one, ONLY for the active par
 
   ALIGN(16)
-  __kmpc_data_sharing_worker_slot_static worker_rootS[WARPSIZE];
+  __kmpc_data_sharing_worker_slot_static worker_rootS[DS_Max_Warp_Number];
   ALIGN(16) __kmpc_data_sharing_master_slot_static master_rootS[1];
 };
 


### PR DESCRIPTION
This is the one of the main issue why memory usage on AMDGPU (~2.3GB) was
larger than NVIDIA (~671MB). With this change, the memory usage by
deviceRTL is around 770MB. This also reduces kernel launch latency.