### PR TITLE
Fixes for Red Hat build.

### DIFF
--- a/openmp/libompd/gdb-plugin/CMakeLists.txt
+++ b/openmp/libompd/gdb-plugin/CMakeLists.txt
@@ -13,15 +13,20 @@ execute_process(COMMAND "${Python3_EXECUTABLE}"
 string(REGEX REPLACE " " ";" PIP_VERSION_INFO "${PIP_VERSION_INFO}")
 list(GET PIP_VERSION_INFO 1 PIP_VERSION)
 set(PYSYSFLAG "")
-if(PIP_VERSION VERSION_LESS_EQUAL "9.0.1")
+if(PIP_VERSION VERSION_LESS_EQUAL "9.0.1" AND NOT DISABLE_SYSTEM_NON_DEBIAN)
   set(PYSYSFLAG "--system")
 endif()
 
 include_directories (${OMPD_INCLUDE_PATH})
 include_directories (${LIBOMP_INCLUDE_DIR})
+
+if(NOT PYTHON_HEADERS)
+  set(PYTHON_HEADERS ${Python3_INCLUDE_DIRS})
+endif()
+
 add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/python-module/loadompd.py
                    DEPEND ompdModule.c loadompd.py setup.py ompd/frame_filter.py ompd/__init__.py ompd/ompd_address_space.py ompd/ompd_callbacks.py ompd/ompd_handles.py ompd/ompd.py
-                   COMMAND ${CMAKE_COMMAND} -E env LIBOMP_INCLUDE_DIR=${LIBOMP_INCLUDE_DIR}
+                   COMMAND ${CMAKE_COMMAND} -E env LIBOMP_INCLUDE_DIR=${LIBOMP_INCLUDE_DIR} env PYTHON_HEADERS=${PYTHON_HEADERS}
                    ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/setup.py -v bdist_wheel -b ${CMAKE_CURRENT_BINARY_DIR}/build -d ${CMAKE_CURRENT_BINARY_DIR}
                    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/setup.py clean --all
                    COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_SOURCE_DIR}/ompd.egg-info

--- a/openmp/libompd/gdb-plugin/setup.py
+++ b/openmp/libompd/gdb-plugin/setup.py
@@ -4,6 +4,7 @@ import os
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 omp_include_dir = os.environ.get('LIBOMP_INCLUDE_DIR', dir_path)
+python_include_dir = os.environ.get('PYTHON_HEADERS', dir_path)
 
 print("find_packages : ", find_packages())
 setup(
@@ -11,5 +12,5 @@ setup(
     version='1.0',
     py_modules=['loadompd'],
     packages=find_packages(),
-	ext_modules=[Extension('ompd.ompdModule', [dir_path+'/ompdModule.c'], include_dirs=[omp_include_dir])]
+	ext_modules=[Extension('ompd.ompdModule', [dir_path+'/ompdModule.c'], include_dirs=[omp_include_dir, python_include_dir])]
 )


### PR DESCRIPTION
The --system flag is not applicable to non-debian operating systems (change to cmake).

Red Hat 7.6 and lower do not provide a python36-devel epel repository.
Therefore, a software collection needs installed at /opt/rh/rh-python36.
The setup.py needs to pass this new python header location or Python.h will not be found.