### PR TITLE
RFC: [OpenMP] Use shared memory for initial team

### DIFF
--- a/clang/lib/CodeGen/CGOpenMPRuntimeNVPTX.h
+++ b/clang/lib/CodeGen/CGOpenMPRuntimeNVPTX.h
@@ -478,6 +478,7 @@ private:
     llvm::Value *GlobalRecordAddr = nullptr;
     llvm::Value *IsInSPMDModeFlag = nullptr;
     std::unique_ptr<CodeGenFunction::OMPMapVars> MappedParams;
+    bool UsedSharedMemory = false;
   };
   /// Maps the function to the list of the globalized variables with their
   /// addresses.


### PR DESCRIPTION
When in target; teams; distribute region, shared memory should be used if possible. This reduces dependency on global memory. Smoke tests went fine. The logic was previously there but was never used, not sure why. Limited testing on NVPTX, but works fine.