### PR TITLE
Embed version number into abs symbol for hostcall_invoke detection

### DIFF
--- a/openmp/libomptarget/deviceRTLs/amdgcn/src/hostrpc_invoke.cl
+++ b/openmp/libomptarget/deviceRTLs/amdgcn/src/hostrpc_invoke.cl
@@ -1,5 +1,7 @@
 #include "ockl_hsa.h"
 
+#include "../../../hostrpc/src/hostrpc.h"
+
 #pragma OPENCL EXTENSION cl_khr_int64_base_atomics : enable
 #pragma OPENCL EXTENSION cl_khr_int64_extended_atomics : enable
 
@@ -301,10 +303,14 @@ hostrpc_invoke( uint service_id,
 // The global variable needs hostcall_buffer is used to detect that
 // host services are required. If this function is not inlined, the symbol
 // will not be present and the runtime can avoid initialising said support.
+#define STR(X) #X
+#define STR2(X) STR(X)
+
 __asm__("; hostcall_invoke: record need for hostcall support\n\t"
-        ".type needs_hostcall_buffer,@object\n\t"
-        ".global needs_hostcall_buffer\n\t"
-        ".comm needs_hostcall_buffer,4":::);
+        "needs_hostcall_buffer = " STR2(HOSTRPC_VRM) "\n\t"
+        :::);
+#undef STR
+#undef STR2
 
   __constant size_t* argptr = (__constant size_t *)__builtin_amdgcn_implicitarg_ptr();
   __global buffer_t * buffer = (__global buffer_t *)argptr[3];

--- a/openmp/libomptarget/hostrpc/src/hostrpc.h
+++ b/openmp/libomptarget/hostrpc/src/hostrpc.h
@@ -32,6 +32,22 @@ SOFTWARE.
 
 */
 
+// Please update at least the patch level when adding a new service.
+// This will ensure that applications that use a new device stub do not
+// try to use backlevel hostcall host runtimes that do not have the
+// implmented host version of the service.
+//
+#define HOSTRPC_VERSION 0
+#define HOSTRPC_RELEASE 6
+#define HOSTRPC_PATCH 3
+// HOSTRPC_VRM fits in two bytes allowing for 64 patches, 64 releases, and 15
+// versions
+#define HOSTRPC_VRM                                                            \
+  ((HOSTRPC_VERSION * 4096) + (HOSTRPC_RELEASE * 64) + HOSTRPC_PATCH)
+#define HOSTRPC_VERSION_RELEASE ((HOSTRPC_VERSION * 64) + HOSTRPC_RELEASE)
+
+#if !defined (__OPENCL_C_VERSION__)
+
 #if defined(__cplusplus)
 #define EXTERN extern "C"
 #else
@@ -77,19 +93,6 @@ EXTERN hostrpc_result_t hostrpc_invoke(uint32_t id, uint64_t arg0,
                                        uint64_t arg5, uint64_t arg6,
                                        uint64_t arg7);
 
-// Please update at least the patch level when adding a new service.
-// This will ensure that applications that use a new device stub do not
-// try to use backlevel hostcall host runtimes that do not have the
-// implmented host version of the service.
-//
-#define HOSTRPC_VERSION 0
-#define HOSTRPC_RELEASE 6
-#define HOSTRPC_PATCH 3
-// HOSTRPC_VRM fits in two bytes allowing for 64 patches, 64 releases, and 15
-// versions
-#define HOSTRPC_VRM                                                            \
-  ((HOSTRPC_VERSION * 4096) + (HOSTRPC_RELEASE * 64) + HOSTRPC_PATCH)
-#define HOSTRPC_VERSION_RELEASE ((HOSTRPC_VERSION * 64) + HOSTRPC_RELEASE)
 typedef short hostcall_version_t;
 
 #define PACK_VERS(x) ((uint32_t)HOSTRPC_VRM << 16) | ((uint32_t)x)
@@ -109,4 +112,5 @@ enum hostcall_service_id {
 };
 typedef enum hostcall_service_id hostcall_service_id_t;
 
+#endif // !defined (__OPENCL__)
 #endif // __HOSTRPC_H__


### PR DESCRIPTION
This change includes the hostcall version macros in hostrpc_invoke then embeds them in the symbol used to detect whether hostcall is in use.

Uses an absolute symbol to save the four bytes. Unfortunately, our loader segfaults on any absolute symbols while loading the executable. So that needs to be fixed before this lands.