### PR TITLE
Call synchronous hsa_memory_copy

### DIFF
--- a/openmp/libomptarget/plugins/amdgpu/src/rtl.cpp
+++ b/openmp/libomptarget/plugins/amdgpu/src/rtl.cpp
@@ -355,6 +355,9 @@ public:
 
   atmi_status_t freesignalpool_memcpy(void *dest, const void *src,
                                       size_t size) {
+    hsa_status_t rc = hsa_memory_copy(dest, src, size);
+    return (rc == HSA_STATUS_SUCCESS) ? ATMI_STATUS_SUCCESS : ATMI_STATUS_ERROR;
+    
     hsa_signal_t s = FreeSignalPool.pop();
     if (s.handle == 0) {
       return ATMI_STATUS_ERROR;

--- a/openmp/libomptarget/plugins/amdgpu/src/rtl.cpp
+++ b/openmp/libomptarget/plugins/amdgpu/src/rtl.cpp
@@ -356,7 +356,14 @@ public:
   atmi_status_t freesignalpool_memcpy(void *dest, const void *src,
                                       size_t size) {
     hsa_status_t rc = hsa_memory_copy(dest, src, size);
-    return (rc == HSA_STATUS_SUCCESS) ? ATMI_STATUS_SUCCESS : ATMI_STATUS_ERROR;
+   
+    // hsa_memory_copy sometimes fails in situations where
+    // allocate + copy succeeds. Looks like it might be related to
+    // locking part of a read only segment. Fall back for now.
+    if (rc == HSA_STATUS_SUCCESS)
+      {
+        return ATMI_STATUS_SUCCESS;
+      }
     
     hsa_signal_t s = FreeSignalPool.pop();
     if (s.handle == 0) {


### PR DESCRIPTION
Minimal patch. Faster in most, possibly all test cases. Exposes a bug in printf with variable format string, pfspecifier_str fails.