### PR TITLE
[DeviceRTL][AMDGPU] Split atmi_memcpy for d2h and h2d

### DIFF
--- a/openmp/libomptarget/plugins/amdgpu/impl/atmi_runtime.h
+++ b/openmp/libomptarget/plugins/amdgpu/impl/atmi_runtime.h
@@ -155,53 +155,16 @@ atmi_status_t atmi_malloc(void **ptr, size_t size, atmi_mem_place_t place);
  */
 atmi_status_t atmi_free(void *ptr);
 
-/**
- * @brief Syncrhonously copy memory from the source to destination memory
- * locations.
- *
- * @detail This function assumes that the source and destination regions are
- * non-overlapping. The runtime determines the memory place of the source and
- * the
- * destination and executes the appropriate optimized data movement methodology.
- *
- * @param[in] dest The destination pointer previously allocated by a system
- * allocator or @p atmi_malloc.
- *
- * @param[in] src The source pointer previously allocated by a system
- * allocator or @p atmi_malloc.
- *
- * @param[in] size The size of the data to be copied in bytes.
- *
- * @retval ::ATMI_STATUS_SUCCESS The function has executed successfully.
- *
- * @retval ::ATMI_STATUS_ERROR The function encountered errors.
- *
- * @retval ::ATMI_STATUS_UNKNOWN The function encountered errors.
- *
- */
-atmi_status_t atmi_memcpy(hsa_signal_t sig, void *dest, const void *src,
-                          size_t size);
+atmi_status_t atmi_memcpy_h2d(hsa_signal_t sig,
+                              void *device_dest,
+                              const void *host_src,
+                              size_t size);
 
-static inline atmi_status_t atmi_memcpy_no_signal(void *dest, const void *src,
-                                                  size_t size) {
-  hsa_signal_t sig;
-  hsa_status_t err = hsa_signal_create(0, 0, NULL, &sig);
-  if (err != HSA_STATUS_SUCCESS) {
-    return ATMI_STATUS_ERROR;
-  }
+atmi_status_t atmi_memcpy_d2h(hsa_signal_t sig,
+                              void *host_dest,
+                              const void *device_src,
+                              size_t size);
 
-  atmi_status_t r = atmi_memcpy(sig, dest, src, size);
-  hsa_status_t rc = hsa_signal_destroy(sig);
-
-  if (r != ATMI_STATUS_SUCCESS) {
-    return r;
-  }
-  if (rc != HSA_STATUS_SUCCESS) {
-    return ATMI_STATUS_ERROR;
-  }
-
-  return ATMI_STATUS_SUCCESS;
-}
 
 /** @} */
 

--- a/openmp/libomptarget/plugins/amdgpu/src/rtl.cpp
+++ b/openmp/libomptarget/plugins/amdgpu/src/rtl.cpp
@@ -28,6 +28,7 @@
 #include <thread>
 #include <unordered_map>
 #include <vector>
+#include <functional>
 
 // Header from ATMI interface
 #include "atmi_interop_hsa.h"
@@ -353,25 +354,29 @@ public:
   static const int Default_WG_Size =
       llvm::omp::AMDGPUGpuGridValues[llvm::omp::GVIDX::GV_Default_WG_Size];
 
+  using MemcpyFunc = std::function<atmi_status_t (hsa_signal_t,
+                                                  void *,
+                                                  const void *,
+                                                  size_t size)>;
   atmi_status_t freesignalpool_memcpy(void *dest, const void *src,
-                                      size_t size) {
-    hsa_status_t rc = hsa_memory_copy(dest, src, size);
-   
-    // hsa_memory_copy sometimes fails in situations where
-    // allocate + copy succeeds. Looks like it might be related to
-    // locking part of a read only segment. Fall back for now.
-    if (rc == HSA_STATUS_SUCCESS)
-      {
-        return ATMI_STATUS_SUCCESS;
-      }
-    
+                                      size_t size, MemcpyFunc Func) {
     hsa_signal_t s = FreeSignalPool.pop();
     if (s.handle == 0) {
       return ATMI_STATUS_ERROR;
     }
-    atmi_status_t r = atmi_memcpy(s, dest, src, size);
+    atmi_status_t r = Func(s, dest, src, size);
     FreeSignalPool.push(s);
     return r;
+  }
+
+  atmi_status_t freesignalpool_memcpy_d2h(void *dest, const void *src,
+                                          size_t size) {
+    return freesignalpool_memcpy(dest, src, size, atmi_memcpy_d2h);
+  }
+
+  atmi_status_t freesignalpool_memcpy_h2d(void *dest, const void *src,
+                                          size_t size) {
+    return freesignalpool_memcpy(dest, src, size, atmi_memcpy_h2d);
   }
 
   // Record entry point associated with device
@@ -570,7 +575,7 @@ int32_t dataRetrieve(int32_t DeviceId, void *HstPtr, void *TgtPtr, int64_t Size,
      (long long unsigned)(Elf64_Addr)TgtPtr,
      (long long unsigned)(Elf64_Addr)HstPtr);
 
-  err = DeviceInfo.freesignalpool_memcpy(HstPtr, TgtPtr, (size_t)Size);
+  err = DeviceInfo.freesignalpool_memcpy_d2h(HstPtr, TgtPtr, (size_t)Size);
 
   if (err != ATMI_STATUS_SUCCESS) {
     DP("Error when copying data from device to host. Pointers: "
@@ -596,7 +601,7 @@ int32_t dataSubmit(int32_t DeviceId, void *TgtPtr, void *HstPtr, int64_t Size,
   DP("Submit data %ld bytes, (hst:%016llx) -> (tgt:%016llx).\n", Size,
      (long long unsigned)(Elf64_Addr)HstPtr,
      (long long unsigned)(Elf64_Addr)TgtPtr);
-  err = DeviceInfo.freesignalpool_memcpy(TgtPtr, HstPtr, (size_t)Size);
+  err = DeviceInfo.freesignalpool_memcpy_h2d(TgtPtr, HstPtr, (size_t)Size);
   if (err != ATMI_STATUS_SUCCESS) {
     DP("Error when copying data from host to device. Pointers: "
        "host = 0x%016lx, device = 0x%016lx, size = %lld\n",
@@ -1060,7 +1065,7 @@ __tgt_target_table *__tgt_rtl_load_binary_locked(int32_t device_id,
     }
 
     // write ptr to device memory so it can be used by later kernels
-    err = DeviceInfo.freesignalpool_memcpy(state_ptr, &ptr, sizeof(void *));
+    err = DeviceInfo.freesignalpool_memcpy_h2d(state_ptr, &ptr, sizeof(void *));
     if (err != ATMI_STATUS_SUCCESS) {
       fprintf(stderr, "memcpy install of state_ptr failed\n");
       return NULL;
@@ -1129,7 +1134,7 @@ __tgt_target_table *__tgt_rtl_load_binary_locked(int32_t device_id,
         // If unified memory is present any target link variables
         // can access host addresses directly. There is no longer a
         // need for device copies.
-        err = DeviceInfo.freesignalpool_memcpy(varptr, e->addr, sizeof(void *));
+        err = DeviceInfo.freesignalpool_memcpy_h2d(varptr, e->addr, sizeof(void *));
         if (err != ATMI_STATUS_SUCCESS)
           DP("Error when copying USM\n");
         DP("Copy linked variable host address (" DPxMOD ")"
@@ -1558,7 +1563,7 @@ static void *AllocateNestedParallelCallMemory(int MaxParLevel, int NumGroups,
   atmi_status_t err =
       atmi_malloc(&TgtPtr, NestedMemSize, get_gpu_mem_place(device_id));
   err =
-      DeviceInfo.freesignalpool_memcpy(CallStackAddr, &TgtPtr, sizeof(void *));
+      DeviceInfo.freesignalpool_memcpy_h2d(CallStackAddr, &TgtPtr, sizeof(void *));
   if (print_kernel_trace > 2)
     fprintf(stderr, "CallSck %lx TgtPtr %lx *TgtPtr %lx \n",
             (long)CallStackAddr, (long)&TgtPtr, (long)TgtPtr);

--- a/openmp/libomptarget/plugins/amdgpu/src/rtl.cpp
+++ b/openmp/libomptarget/plugins/amdgpu/src/rtl.cpp
@@ -354,10 +354,10 @@ public:
   static const int Default_WG_Size =
       llvm::omp::AMDGPUGpuGridValues[llvm::omp::GVIDX::GV_Default_WG_Size];
 
-  using MemcpyFunc = std::function<atmi_status_t (hsa_signal_t,
-                                                  void *,
-                                                  const void *,
-                                                  size_t size)>;
+  using MemcpyFunc = atmi_status_t (hsa_signal_t,
+                                    void *,
+                                    const void *,
+                                    size_t size);
   atmi_status_t freesignalpool_memcpy(void *dest, const void *src,
                                       size_t size, MemcpyFunc Func) {
     hsa_signal_t s = FreeSignalPool.pop();

--- a/openmp/libomptarget/plugins/amdgpu/src/rtl.cpp
+++ b/openmp/libomptarget/plugins/amdgpu/src/rtl.cpp
@@ -28,7 +28,6 @@
 #include <thread>
 #include <unordered_map>
 #include <vector>
-#include <functional>
 
 // Header from ATMI interface
 #include "atmi_interop_hsa.h"


### PR DESCRIPTION
This patch is mostly NFC as the underlying copy is still done by generic atmi_memcpy. Call sites, however, are updated to use the respective copy method as they already know which direction they are going to copy in.  Future patch will remove the check for the direction from the memcpy implementation.