### PR TITLE
Add a fatal error if missing -Xopenmp-target option when -fopenmp-tar…

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -114,6 +114,9 @@ def err_drv_invalid_darwin_version : Error<
   "invalid Darwin version number: %0">;
 def err_drv_missing_argument : Error<
   "argument to '%0' is missing (expected %1 value%s1)">;
+def err_drv_missing_Xopenmptarget_or_march: Error<
+  "The option -fopenmp-targets= requires additional options -Xopenmp-target= and -march= .">,
+  DefaultFatal;
 def err_drv_invalid_Xarch_argument_with_args : Error<
   "invalid Xarch argument: '%0', options requiring arguments are unsupported">;
 def err_drv_invalid_Xarch_argument_isdriver : Error<

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -703,6 +703,21 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
   // the -fopenmp-targets option.
   if (Arg *OpenMPTargets =
           C.getInputArgs().getLastArg(options::OPT_fopenmp_targets_EQ)) {
+    // Ensure at least one -Xopenm-target exists with a gpu -march
+    if (Arg *XOpenMPTargets =
+            C.getInputArgs().getLastArg(options::OPT_Xopenmp_target_EQ)) {
+      bool has_valid_march = false;
+      for (auto *V : XOpenMPTargets->getValues())
+        if (StringRef(V).startswith("-march="))
+          has_valid_march = true;
+      if (!has_valid_march) {
+        Diag(diag::err_drv_missing_Xopenmptarget_or_march);
+        return;
+      }
+    } else {
+      Diag(diag::err_drv_missing_Xopenmptarget_or_march);
+      return;
+    }
     if (OpenMPTargets->getNumValues()) {
       // We expect that -fopenmp-targets is always used in conjunction with the
       // option -fopenmp specifying a valid runtime with offloading support,


### PR DESCRIPTION
…gets is specified.  This fixes smoke test omp_get_initial which should be an expected fail.