### PR TITLE
Limit default number of teams to number of CUs

### DIFF
--- a/openmp/libomptarget/plugins/amdgpu/src/rtl.cpp
+++ b/openmp/libomptarget/plugins/amdgpu/src/rtl.cpp
@@ -754,9 +754,16 @@ int32_t __tgt_rtl_init_device(int device_id) {
     DP("Default number of teams set according to environment %d\n",
        DeviceInfo.EnvNumTeams);
   } else {
-    // default number of teams is 1:1 with number of compute units.
-    DeviceInfo.NumTeams[device_id] = DeviceInfo.ComputeUnits[device_id];
-    DP("Default number of teams set according to number of compute units %d\n",
+    char *TeamsPerCUEnvStr = getenv("AMDGPU_TEAMS_PER_CU");
+    int TeamsPerCU = 1; // default number of teams per CU is 1
+    if (TeamsPerCUEnvStr) {
+      TeamsPerCU = std::stoi(TeamsPerCUEnvStr);
+    }
+   
+    DeviceInfo.NumTeams[device_id] =
+      TeamsPerCU * DeviceInfo.ComputeUnits[device_id];
+    DP("Default number of teams = %d * number of compute units %d\n",
+       TeamsPerCU,
        DeviceInfo.ComputeUnits[device_id]);
   }
 

--- a/openmp/libomptarget/plugins/amdgpu/src/rtl.cpp
+++ b/openmp/libomptarget/plugins/amdgpu/src/rtl.cpp
@@ -754,7 +754,7 @@ int32_t __tgt_rtl_init_device(int device_id) {
     DP("Default number of teams set according to environment %d\n",
        DeviceInfo.EnvNumTeams);
   } else {
-    char *TeamsPerCUEnvStr = getenv("OMP_TARGET_DEFAULT_TEAMS_PER_PROC");
+    char *TeamsPerCUEnvStr = getenv("OMP_TARGET_TEAMS_PER_PROC");
     int TeamsPerCU = 1; // default number of teams per CU is 1
     if (TeamsPerCUEnvStr) {
       TeamsPerCU = std::stoi(TeamsPerCUEnvStr);

--- a/openmp/libomptarget/plugins/amdgpu/src/rtl.cpp
+++ b/openmp/libomptarget/plugins/amdgpu/src/rtl.cpp
@@ -754,7 +754,7 @@ int32_t __tgt_rtl_init_device(int device_id) {
     DP("Default number of teams set according to environment %d\n",
        DeviceInfo.EnvNumTeams);
   } else {
-    char *TeamsPerCUEnvStr = getenv("AMDGPU_TEAMS_PER_CU");
+    char *TeamsPerCUEnvStr = getenv("OMP_TARGET_DEFAULT_TEAMS_PER_PROC");
     int TeamsPerCU = 1; // default number of teams per CU is 1
     if (TeamsPerCUEnvStr) {
       TeamsPerCU = std::stoi(TeamsPerCUEnvStr);


### PR DESCRIPTION
Default number of teams when launched with #pragma omp target teams would be equal to the number of CUs. Previously it was hard coded to 128.