### PR TITLE
do not let kernel args be captured vars that are lvalue expressions t…

### DIFF
--- a/clang/lib/CodeGen/CGStmtOpenMP.cpp
+++ b/clang/lib/CodeGen/CGStmtOpenMP.cpp
@@ -481,6 +481,13 @@ static llvm::Function *emitOutlinedFunctionPrologue(
         if (LLVM_AS == LangAS::Default)
           LLVM_AS = LangAS::cuda_device;
         ArgType = Ctx.getAddrSpaceQualType(ArgType, LLVM_AS);
+        if ((ArgType.getTypePtr()->isLValueReferenceType()) &&
+            ArgType.getTypePtr()
+                ->getAs<ReferenceType>()
+                ->getPointeeType()
+                .getTypePtr()
+                ->isAnyPointerType())
+          ArgType = ArgType.getNonLValueExprType(Ctx);
       }
     }
 
@@ -593,8 +600,10 @@ static llvm::Function *emitOutlinedFunctionPrologue(
         ArgAddr = CGF.EmitLoadOfReference(ArgLVal);
       } else if (!VarTy->isVariablyModifiedType() || !VarTy->isPointerType()) {
         assert(ArgLVal.getType()->isPointerType());
-        ArgAddr = CGF.EmitLoadOfPointer(
-            ArgAddr, ArgLVal.getType()->castAs<PointerType>());
+        if (!FD->getType()->isLValueReferenceType()) {
+          ArgAddr = CGF.EmitLoadOfPointer(
+              ArgAddr, ArgLVal.getType()->castAs<PointerType>());
+        }
       }
       if (!FO.RegisterCastedArgsOnly) {
         LocalAddrs.insert(


### PR DESCRIPTION
…o a pointer.  Change the generated type to getNonLValueExprType and skip the generation of the pointer reference

This is the fix for Devito. Where they declare a pointer with __attribute__ ((alligned(64)))