### PR TITLE
we are switching the build of openmp runtime and libomptarget to use …

### DIFF
--- a/openmp/libomptarget/hostrpc/services/hostcall.cpp
+++ b/openmp/libomptarget/hostrpc/services/hostcall.cpp
@@ -118,7 +118,6 @@ struct amd_hostcall_consumer_t {
 private:
   signal_t doorbell;
   std::thread thread;
-  void *error_callback_data;
   critical_data_t critical_data;
 
   amd_hostcall_consumer_t(signal_t _doorbell) : doorbell(_doorbell) {}

--- a/openmp/libomptarget/plugins/amdgpu/impl/data.cpp
+++ b/openmp/libomptarget/plugins/amdgpu/impl/data.cpp
@@ -36,9 +36,12 @@ const char *getPlaceStr(atmi_devtype_t type) {
 ATLProcessor &get_processor_by_mem_place(atmi_mem_place_t place) {
   int dev_id = place.dev_id;
   switch (place.dev_type) {
+  case ATMI_DEVTYPE_ALL:
   case ATMI_DEVTYPE_CPU:
     return g_atl_machine.processors<ATLCPUProcessor>()[dev_id];
   case ATMI_DEVTYPE_GPU:
+  case ATMI_DEVTYPE_iGPU:
+  case ATMI_DEVTYPE_dGPU:
     return g_atl_machine.processors<ATLGPUProcessor>()[dev_id];
   }
 }

--- a/openmp/libomptarget/plugins/amdgpu/impl/elf_amd.h
+++ b/openmp/libomptarget/plugins/amdgpu/impl/elf_amd.h
@@ -41,6 +41,7 @@ enum : unsigned {
   EF_AMDGPU_SRAM_ECC = 0x200,
 };
 
+/*  These functions commented out till we use them in rtl.cpp
 static bool get_elf_mach_sram_ecc(__tgt_device_image *image) {
   uint32_t EFlags = elf_flags(image);
   return (EF_AMDGPU_SRAM_ECC & EFlags) != 0;
@@ -50,6 +51,7 @@ static bool get_elf_mach_xnack(__tgt_device_image *image) {
   uint32_t EFlags = elf_flags(image);
   return (EF_AMDGPU_XNACK & EFlags) != 0;
 }
+*/
 
 static int get_elf_mach_gfx(__tgt_device_image *image) {
   uint32_t EFlags = elf_flags(image);

--- a/openmp/libomptarget/plugins/amdgpu/src/rtl.cpp
+++ b/openmp/libomptarget/plugins/amdgpu/src/rtl.cpp
@@ -201,7 +201,7 @@ struct KernelTy {
   int8_t ExecutionMode;
   int16_t ConstWGSize;
   int32_t device_id;
-  void *CallStackAddr;
+  void *CallStackAddr = nullptr;
   const char *Name;
 
   KernelTy(int8_t _ExecutionMode, int16_t _ConstWGSize,
@@ -342,7 +342,8 @@ public:
   std::vector<std::pair<std::unique_ptr<void, atmiFreePtrDeletor>, uint64_t>>
       deviceStateStore;
 
-  static const int HardTeamLimit = 1 << 20; // 1 Meg
+  static const unsigned HardTeamLimit =
+      (1 << 16) - 1; // 64K needed to fit in uint16
   static const int DefaultNumTeams = 128;
   static const int Max_Teams =
       llvm::omp::AMDGPUGpuGridValues[llvm::omp::GVIDX::GV_Max_Teams];
@@ -862,7 +863,7 @@ const Elf64_Sym *elf_lookup(Elf *elf, char *base, Elf64_Shdr *section_hash,
   return nullptr;
 }
 
-typedef struct {
+typedef struct symbol_info {
   void *addr = nullptr;
   uint32_t size = UINT32_MAX;
 } symbol_info;
@@ -1213,7 +1214,7 @@ __tgt_target_table *__tgt_rtl_load_binary_locked(int32_t device_id,
 
     void *KernDescPtr;
     uint32_t KernDescSize;
-    void *CallStackAddr;
+    void *CallStackAddr = nullptr;
     err = interop_get_symbol_info((char *)image->ImageStart, img_size,
                                   KernDescName, &KernDescPtr, &KernDescSize);
 

--- a/openmp/libomptarget/src/rtl.cpp
+++ b/openmp/libomptarget/src/rtl.cpp
@@ -215,7 +215,7 @@ void RTLsTy::LoadRTLs() {
     // The RTL is valid! Will save the information in the RTLs list.
     AllRTLs.push_back(R);
   }
-  delete libomptarget_dir_name;
+  delete[] libomptarget_dir_name;
   DP("RTLs loaded!\n");
 
   return;


### PR DESCRIPTION
…clang. This PR fixes all the warnings that result from using clang


REVIEW QUICKLY.   This is going to be merged for AOMP 11.12-0 release. 