### PR TITLE
Fix race. Zero init array once, not once per image

### DIFF
--- a/openmp/libomptarget/plugins/amdgpu/src/rtl.cpp
+++ b/openmp/libomptarget/plugins/amdgpu/src/rtl.cpp
@@ -946,6 +946,26 @@ __tgt_target_table *__tgt_rtl_load_binary(int32_t device_id,
   return res;
 }
 
+static atmi_status_t atmi_calloc(void **ret_ptr, size_t size,
+                                 atmi_mem_place_t place) {
+  uint64_t rounded = 4 * ((size + 3) / 4);
+  void *ptr;
+  atmi_status_t err = atmi_malloc(&ptr, rounded, place);
+  if (err != ATMI_STATUS_SUCCESS) {
+    return err;
+  }
+
+  hsa_status_t rc = hsa_amd_memory_fill(ptr, 0, rounded / 4);
+  if (rc != HSA_STATUS_SUCCESS) {
+    fprintf(stderr, "zero fill device_state failed with %u\n", rc);
+    atmi_free(ptr);
+    return ATMI_STATUS_ERROR;
+  }
+
+  *ret_ptr = ptr;
+  return ATMI_STATUS_SUCCESS;
+}
+
 __tgt_target_table *__tgt_rtl_load_binary_locked(int32_t device_id,
                                                  __tgt_device_image *image) {
   // This function loads the device image onto gpu[device_id] and does other
@@ -1042,7 +1062,7 @@ __tgt_target_table *__tgt_rtl_load_binary_locked(int32_t device_id,
       assert(dss.second == 0);
       void *ptr = NULL;
       atmi_status_t err =
-          atmi_malloc(&ptr, device_State_bytes, get_gpu_mem_place(device_id));
+          atmi_calloc(&ptr, device_State_bytes, get_gpu_mem_place(device_id));
       if (err != ATMI_STATUS_SUCCESS) {
         fprintf(stderr, "Failed to allocate device_state array\n");
         return NULL;
@@ -1078,13 +1098,6 @@ __tgt_target_table *__tgt_rtl_load_binary_locked(int32_t device_id,
                                                device_id);
     if (err != ATMI_STATUS_SUCCESS) {
       fprintf(stderr, "memcpy install of state_ptr failed\n");
-      return NULL;
-    }
-
-    assert((device_State_bytes & 0x3) == 0); // known >= 4 byte aligned
-    hsa_status_t rc = hsa_amd_memory_fill(ptr, 0, device_State_bytes / 4);
-    if (rc != HSA_STATUS_SUCCESS) {
-      fprintf(stderr, "zero fill device_state failed with %u\n", rc);
       return NULL;
     }
   }


### PR DESCRIPTION
Patch fixes exactly this issue and makes no other changes.

The device_State array is allocated once, when the first gpu image is loaded as that is when the required size is known. This allocation is reused for all images on the same gpu, as it can be, and that decreases memory footprint considerably.

Prior to this patch, the array was zero-initialised after copying the pointer to the gpu image. This means it is zero-initialised once per image, so if a previous kernel is still using the storage at the time, it'll be clobbered by loading the next image. This bug is latent.

The fix is to zero initialise once. Load binary is called under a mutex. To keep the patch clean, this is done by writing atmi_calloc in terms of atmi_malloc and hsa_amd_memory_fill. The naming and API is chosen for consistency with the existing memory routines.