### PR TITLE
Reorder two fields in device_environmentTy

### DIFF
--- a/openmp/libomptarget/src/device_env_struct.h
+++ b/openmp/libomptarget/src/device_env_struct.h
@@ -22,7 +22,7 @@
 struct omptarget_device_environmentTy {
   int32_t debug_level; // gets value of envvar LIBOMPTARGET_DEVICE_RTL_DEBUG
                        // only useful for Debug build of deviceRTLs
-  int32_t num_devices; // gets number of active offload devices
   int32_t device_num;  // gets a value 0 to num_devices-1
+  int32_t num_devices; // gets number of active offload devices
 };
 #endif


### PR DESCRIPTION
Trunk presently has only the debug_level field.

Review D91713 adds a device_num field. num_devices is more contentious.

This change swaps the two extra fields so that, once the above lands, the device_num field will be at the same offset in the deviceRTL, regardless of whether it is from trunk or rocm.

Applied to amd-stg-open as 450748