### PR TITLE
Add additional path to INSTALL_RPATH for amdpgu plugin.

### DIFF
--- a/openmp/libomptarget/plugins/amdgpu/CMakeLists.txt
+++ b/openmp/libomptarget/plugins/amdgpu/CMakeLists.txt
@@ -72,7 +72,7 @@ add_definitions(${OPENMP_SOURCE_DEBUG_MAP})
 # When we build for debug, OPENMP_LIBDIR_SUFFIX get set to -debug
 install(TARGETS omptarget.rtl.amdgpu LIBRARY DESTINATION "lib${OPENMP_LIBDIR_SUFFIX}")
 
-set_property(TARGET omptarget.rtl.amdgpu PROPERTY INSTALL_RPATH "$ORIGIN")
+set_property(TARGET omptarget.rtl.amdgpu PROPERTY INSTALL_RPATH "$ORIGIN:$ORIGIN/../lib")
 target_link_libraries(
   omptarget.rtl.amdgpu
   PUBLIC


### PR DESCRIPTION
The debug build of the amdgpu plugin needs to find libhsa-runtime64.so, which resides in ORIGIN/../lib.
This can also be resolved in the future by adding debug builds of rocr/roct to lib-debug or
statically linking them into the plugin.